### PR TITLE
make vector indexing work with all extrapolations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 sudo: false
 julia:
-    - 0.4
     - 0.5
     - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 
 WoodburyMatrices 0.1.5
 Ratios

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -37,7 +37,7 @@ export
 using Compat
 using WoodburyMatrices, Ratios, AxisAlgorithms
 
-import Base: convert, size, getindex, gradient, promote_rule, ndims, eltype
+import Base: convert, size, getindex, gradient, promote_rule, ndims, eltype, checkbounds
 
 # Julia v0.5 compatibility
 if isdefined(:scaling) import Base.scaling end

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -54,9 +54,11 @@ function getindex_impl{T,N,ITPT,IT,GT,ET}(etp::Type{Extrapolation{T,N,ITPT,IT,GT
     end
 end
 
-@generated function getindex{T,N,ITPT,IT,GT,ET}(etp::Extrapolation{T,N,ITPT,IT,GT,ET}, xs...)
+@generated function getindex{T,N,ITPT,IT,GT,ET}(etp::Extrapolation{T,N,ITPT,IT,GT,ET}, xs::Number...)
     getindex_impl(etp, xs...)
 end
+
+checkbounds(::AbstractExtrapolation,I...) = nothing
 
 
 function gradient!_impl{T,N,ITPT,IT,GT,ET}(g, etp::Type{Extrapolation{T,N,ITPT,IT,GT,ET}}, xs...)

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -83,7 +83,7 @@ etp100g = extrapolate(interpolate(([10;20],),[100;110], Gridded(Linear())), Flat
 
 # check all extrapolations work with vectorized indexing
 for E in [0,Flat(),Linear(),Periodic(),Reflect()]
-    @test (@inferred(getindex(extrapolate(interpolate([0,0],BSpline(Linear()),OnGrid()),E),[3]))) == [0]
+    @test (@inferred(getindex(extrapolate(interpolate([0,0],BSpline(Linear()),OnGrid()),E),[1.2, 1.8, 3.1]))) == [0,0,0]
 end
 
 end

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -79,6 +79,13 @@ etp100g = extrapolate(interpolate(([10;20],),[100;110], Gridded(Linear())), Flat
 @test @inferred(getindex(etp100g, 5)) == 100
 @test @inferred(getindex(etp100g, 15)) == 105
 @test @inferred(getindex(etp100g, 25)) == 110
+
+
+# check all extrapolations work with vectorized indexing
+for E in [0,Flat(),Linear(),Periodic(),Reflect()]
+    @test (@inferred extrapolate(interpolate([0,0],BSpline(Linear()),OnGrid()),E)[[3]]) == [0]
+end
+
 end
 
 include("type-stability.jl")

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -83,7 +83,7 @@ etp100g = extrapolate(interpolate(([10;20],),[100;110], Gridded(Linear())), Flat
 
 # check all extrapolations work with vectorized indexing
 for E in [0,Flat(),Linear(),Periodic(),Reflect()]
-    @test (@inferred extrapolate(interpolate([0,0],BSpline(Linear()),OnGrid()),E)[[3]]) == [0]
+    @test (@inferred(getindex(extrapolate(interpolate([0,0],BSpline(Linear()),OnGrid()),E),[3]))) == [0]
 end
 
 end


### PR DESCRIPTION
Makes e.g. this work,

```julia
julia> itp = extrapolate(interpolate([1,2],BSpline(Linear()),OnGrid()),0)
2-element Interpolations.FilledExtrapolation{Float64,1,Interpolations.BSplineInterpolation{Float64,1,Array{Float64,1},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,0},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,Float64}:
 1.0
 2.0

julia> itp[[0,1,2,3]]
4-element Array{Float64,1}:
 0.0
 1.0
 2.0
 0.0
```
with all extrapolation types (previously only some worked). 

I just let `getindex` fall through to the default implementation, and added a `checkbounds` which always succeeds since we are extrapolating to no-matter-where. Tests seem to be passing including the new ones I've written, but I'm not at all familiar with this code-base, so someone please check me! 

I think this also fully closes https://github.com/JuliaMath/Interpolations.jl/issues/128