### PR TITLE
Add construction and usage benchmarks for BSpline

### DIFF
--- a/perf/benchmarks.jl
+++ b/perf/benchmarks.jl
@@ -10,17 +10,21 @@ end
 
 # To evaluate at fractional positions without any "unnecessary"
 # overhead, safer to use Base.Cartesian
-@generated function sumvalues{T,N}(itp::AbstractInterpolation{T,N})
-    n = Int(round(1000^(1/N)))
+@generated function sumvalues{T,N}(itp::AbstractInterpolation{T,N}, inds)
     quote
-        inds = indices(itp)
-        @nexprs $N d->inds_d = linspace(first(inds[d])+0.001, last(inds[d])-0.001, $n)
+        @nexprs $N d->inds_d = inds[d]
         s = zero(eltype(itp))
-        @nloops $N i d->inds_d begin
-            @inbounds s += @nref($N, itp, i)
+        @inbounds @nloops $N i d->inds_d begin
+            s += @nref($N, itp, i)
         end
         s
     end
+end
+
+function sumvalues_indices(itp)
+    inds = indices(itp)
+    n = Int(round(10^(3/ndims(itp))))
+    ntuple(d->collect(linspace(first(inds[d])+0.001, last(inds[d])-0.001, n)), ndims(itp))
 end
 
 strip_prefix(str) = replace(str, "Interpolations.", "")
@@ -51,8 +55,9 @@ for A in (collect(Float64, 1:3),
             suite["bsplines"][gstr][string(idstr, "_construct")] =
                 @benchmarkable interpolate($Ac, BSpline($D()), $GT())
             itp = interpolate(copy(A), BSpline(D()), GT())
+            inds = sumvalues_indices(itp)
             suite["bsplines"][gstr][string(idstr, "_use")] =
-                @benchmarkable sumvalues($itp)
+                @benchmarkable sumvalues($itp, $inds)
         end
     end
     # Quadratic
@@ -63,8 +68,9 @@ for A in (collect(Float64, 1:3),
         suite["bsplines"][gstr][string(idstr, "_construct")] =
             @benchmarkable interpolate($Ac, BSpline(Quadratic($BC())), $GT())
         itp = interpolate(copy(A), BSpline(Quadratic(BC())), GT())
+        inds = sumvalues_indices(itp)
         suite["bsplines"][gstr][string(idstr, "_use")] =
-            @benchmarkable sumvalues($itp)
+            @benchmarkable sumvalues($itp, $inds)
     end
     for BC in (InPlace,InPlaceQ)
         Ac = copy(A)
@@ -72,8 +78,9 @@ for A in (collect(Float64, 1:3),
         suite["bsplines"][gstr][string(idstr, "_construct")] =
             @benchmarkable interpolate!($Ac, BSpline(Quadratic($BC())), OnCell())
         itp = interpolate!(copy(A), BSpline(Quadratic(BC())), OnCell())
+        inds = sumvalues_indices(itp)
         suite["bsplines"][gstr][string(idstr, "_use")] =
-            @benchmarkable sumvalues($itp)
+            @benchmarkable sumvalues($itp, $inds)
     end
     # Cubic
     gstr = groupstr(Cubic)
@@ -83,8 +90,9 @@ for A in (collect(Float64, 1:3),
         suite["bsplines"][gstr][string(idstr, "_construct")] =
             @benchmarkable interpolate($Ac, BSpline(Cubic($BC())), $GT())
         itp = interpolate(copy(A), BSpline(Cubic(BC())), GT())
+        inds = sumvalues_indices(itp)
         suite["bsplines"][gstr][string(idstr, "_use")] =
-            @benchmarkable sumvalues($itp)
+            @benchmarkable sumvalues($itp, $inds)
     end
 end
 
@@ -93,6 +101,7 @@ paramspath = joinpath(dirname(@__FILE__), "params.jld")
 if isfile(paramspath)
     loadparams!(suite, BenchmarkTools.load(paramspath, "suite"), :evals);
 else
+    info("Tuning suite (this may take a while)")
     tune!(suite)
     BenchmarkTools.save(paramspath, "suite", params(suite));
 end

--- a/perf/benchmarks.jl
+++ b/perf/benchmarks.jl
@@ -1,0 +1,98 @@
+using BenchmarkTools, Base.Cartesian
+using Interpolations
+
+const suite = BenchmarkGroup()
+
+suite["bsplines"] = BenchmarkGroup()
+for bspline in ["constant", "linear", "quadratic", "cubic"]
+    suite["bsplines"][bspline] = BenchmarkGroup()
+end
+
+# To evaluate at fractional positions without any "unnecessary"
+# overhead, safer to use Base.Cartesian
+@generated function sumvalues{T,N}(itp::AbstractInterpolation{T,N})
+    n = Int(round(1000^(1/N)))
+    quote
+        inds = indices(itp)
+        @nexprs $N d->inds_d = linspace(first(inds[d])+0.001, last(inds[d])-0.001, $n)
+        s = zero(eltype(itp))
+        @nloops $N i d->inds_d begin
+            @inbounds s += @nref($N, itp, i)
+        end
+        s
+    end
+end
+
+strip_prefix(str) = replace(str, "Interpolations.", "")
+benchstr{T<:Interpolations.GridType}(::Type{T}) = strip_prefix(string(T))
+
+benchstr(::Type{Constant}) = "Constant()"
+benchstr(::Type{Linear}) = "Linear()"
+benchstr{BC<:Interpolations.Flag}(::Type{Quadratic{BC}}) =
+    string("Quadratic(", strip_prefix(string(BC)), "())")
+benchstr{BC<:Interpolations.Flag}(::Type{Cubic{BC}}) =
+    string("Quadratic(", strip_prefix(string(BC)), "())")
+
+groupstr(::Type{Constant}) = "constant"
+groupstr(::Type{Linear}) = "linear"
+groupstr(::Type{Quadratic}) = "quadratic"
+groupstr(::Type{Cubic}) = "cubic"
+
+
+for A in (collect(Float64, 1:3),
+          reshape(collect(Float64, 1:9), 3, 3),
+          reshape(collect(Float64, 1:27), 3, 3, 3))
+    # Constant & Linear
+    for D in (Constant, Linear)
+        gstr = groupstr(D)
+        for GT in (OnGrid, OnCell)
+            Ac = copy(A)
+            idstr = string(ndims(A), "d_", benchstr(D), '_', benchstr(GT))
+            suite["bsplines"][gstr][string(idstr, "_construct")] =
+                @benchmarkable interpolate($Ac, BSpline($D()), $GT())
+            itp = interpolate(copy(A), BSpline(D()), GT())
+            suite["bsplines"][gstr][string(idstr, "_use")] =
+                @benchmarkable sumvalues($itp)
+        end
+    end
+    # Quadratic
+    gstr = groupstr(Quadratic)
+    for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
+        Ac = copy(A)
+        idstr = string(ndims(A), "d_", benchstr(Quadratic{BC}), '_', benchstr(GT))
+        suite["bsplines"][gstr][string(idstr, "_construct")] =
+            @benchmarkable interpolate($Ac, BSpline(Quadratic($BC())), $GT())
+        itp = interpolate(copy(A), BSpline(Quadratic(BC())), GT())
+        suite["bsplines"][gstr][string(idstr, "_use")] =
+            @benchmarkable sumvalues($itp)
+    end
+    for BC in (InPlace,InPlaceQ)
+        Ac = copy(A)
+        idstr = string(ndims(A), "d_", benchstr(Quadratic{BC}), '_', benchstr(OnCell))
+        suite["bsplines"][gstr][string(idstr, "_construct")] =
+            @benchmarkable interpolate!($Ac, BSpline(Quadratic($BC())), OnCell())
+        itp = interpolate!(copy(A), BSpline(Quadratic(BC())), OnCell())
+        suite["bsplines"][gstr][string(idstr, "_use")] =
+            @benchmarkable sumvalues($itp)
+    end
+    # Cubic
+    gstr = groupstr(Cubic)
+    for BC in (Flat,Line,Free,Periodic), GT in (OnGrid, OnCell)
+        Ac = copy(A)
+        idstr = string(ndims(A), "d_", benchstr(Cubic{BC}), '_', benchstr(GT))
+        suite["bsplines"][gstr][string(idstr, "_construct")] =
+            @benchmarkable interpolate($Ac, BSpline(Cubic($BC())), $GT())
+        itp = interpolate(copy(A), BSpline(Cubic(BC())), GT())
+        suite["bsplines"][gstr][string(idstr, "_use")] =
+            @benchmarkable sumvalues($itp)
+    end
+end
+
+paramspath = joinpath(dirname(@__FILE__), "params.jld")
+
+if isfile(paramspath)
+    loadparams!(suite, BenchmarkTools.load(paramspath, "suite"), :evals);
+else
+    tune!(suite)
+    BenchmarkTools.save(paramspath, "suite", params(suite));
+end


### PR DESCRIPTION
I'm preparing to make some changes to the basic indexing rules, and before embarking on that I wanted a simple way to find out what I'd messed up :smile:. This uses the wonderful [BenchmarkTools](https://github.com/JuliaCI/BenchmarkTools.jl) framework; by emulating the "recipes" in [BaseBenchmarks](https://github.com/JuliaCI/BaseBenchmarks.jl), one can pretty easily compare performance between master and a PR.

Let's all give a round of applause to @jrevels for making this so easy! :clap: 
