### PR TITLE
Support arbitrary indices for interpolation & extrapolation

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -37,7 +37,8 @@ export
 using Compat
 using WoodburyMatrices, Ratios, AxisAlgorithms
 
-import Base: convert, size, getindex, gradient, promote_rule, ndims, eltype, checkbounds
+import Base: convert, size, indices, getindex, gradient, promote_rule,
+             ndims, eltype, checkbounds
 
 # Julia v0.5 compatibility
 if isdefined(:scaling) import Base.scaling end

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -11,7 +11,7 @@ Constant
 """
 function define_indices_d(::Type{BSpline{Constant}}, d, pad)
     symix, symx = Symbol("ix_",d), Symbol("x_",d)
-    :($symix = clamp(round(Int, $symx), 1, size(itp, $d)))
+    :($symix = clamp(round(Int, $symx), first(inds_itp[$d]), last(inds_itp[$d])))
 end
 
 """

--- a/src/b-splines/cubic.jl
+++ b/src/b-splines/cubic.jl
@@ -35,7 +35,7 @@ function define_indices_d{BC}(::Type{BSpline{Cubic{BC}}}, d, pad)
     quote
         # ensure that all of ix_d, ixm_d, ixp_d, and ixpp_d are in-bounds no
         # matter the value of pad
-        $symix = clamp(floor(Int, $symx), $(2-pad), size(itp,$d)+$(pad-2))
+        $symix = clamp(floor(Int, $symx), first(inds_itp[$d]) + $(1-pad), last(inds_itp[$d]) + $(pad-2))
         $symfx = $symx - $symix
         $symix += $pad # padding for oob coefficient
         $symixm = $symix - 1
@@ -56,11 +56,12 @@ function define_indices_d(::Type{BSpline{Cubic{Periodic}}}, d, pad)
     symix, symixm, symixp = Symbol("ix_",d), Symbol("ixm_",d), Symbol("ixp_",d)
     symixpp, symx, symfx = Symbol("ixpp_",d), Symbol("x_",d), Symbol("fx_",d)
     quote
-        $symix = clamp(floor(Int, $symx), 1, size(itp,$d))
+        tmp = inds_itp[$d]
+        $symix = clamp(floor(Int, $symx), first(tmp), last(tmp))
         $symfx = $symx - $symix
-        $symixm = mod1($symix - 1, size(itp,$d))
-        $symixp = mod1($symix + 1, size(itp,$d))
-        $symixpp = mod1($symix + 2, size(itp,$d))
+        $symixm = modrange($symix - 1, tmp)
+        $symixp = modrange($symix + 1, tmp)
+        $symixpp = modrange($symix + 2, tmp)
     end
 end
 

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -32,6 +32,7 @@ function getindex_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad
     quote
         $meta
         @nexprs $N d->(x_d = xs[d])
+        inds_itp = indices(itp)
 
         # Calculate the indices of all coefficients that will be used
         # and define fx = x - xi in each dimension
@@ -69,6 +70,7 @@ function gradient_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad
         $meta
         length(g) == $n || throw(ArgumentError(string("The length of the provided gradient vector (", length(g), ") did not match the number of interpolating dimensions (", n, ")")))
         @nexprs $N d->(x_d = xs[d])
+        inds_itp = indices(itp)
 
         # Calculate the indices of all coefficients that will be used
         # and define fx = x - xi in each dimension
@@ -130,6 +132,7 @@ function hessian_impl{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad}
         $meta
         size(H) == ($n,$n) || throw(ArgumentError(string("The size of the provided Hessian matrix wasn't a square matrix of size ", size(H))))
         @nexprs $N d->(x_d = xs[d])
+        inds_itp = indices(itp)
 
         $(define_indices(IT, N, Pad))
 

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -29,7 +29,7 @@ Linear
 function define_indices_d(::Type{BSpline{Linear}}, d, pad)
     symix, symixp, symfx, symx = Symbol("ix_",d), Symbol("ixp_",d), Symbol("fx_",d), Symbol("x_",d)
     quote
-        $symix = clamp(floor(Int, $symx), 1, size(itp, $d)-1)
+        $symix = clamp(floor(Int, $symx), first(inds_itp[$d]), last(inds_itp[$d])-1)
         $symixp = $symix + 1
         $symfx = $symx - $symix
     end

--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -34,7 +34,7 @@ function define_indices_d{BC}(::Type{BSpline{Quadratic{BC}}}, d, pad)
     quote
         # ensure that all three ix_d, ixm_d, and ixp_d are in-bounds no matter
         # the value of pad
-        $symix = clamp(round(Int, $symx), 2-$pad, size(itp,$d)+$pad-1)
+        $symix = clamp(round(Int, $symx), first(inds_itp[$d])+1-$pad, last(inds_itp[$d])+$pad-1)
         $symfx = $symx - $symix
         $symix += $pad # padding for oob coefficient
         $symixp = $symix + 1
@@ -45,10 +45,10 @@ function define_indices_d(::Type{BSpline{Quadratic{Periodic}}}, d, pad)
     symix, symixm, symixp = Symbol("ix_",d), Symbol("ixm_",d), Symbol("ixp_",d)
     symx, symfx = Symbol("x_",d), Symbol("fx_",d)
     quote
-        $symix = clamp(round(Int, $symx), 1, size(itp,$d))
+        $symix = clamp(round(Int, $symx), first(inds_itp[$d]), last(inds_itp[$d]))
         $symfx = $symx - $symix
-        $symixp = mod1($symix + 1, size(itp,$d))
-        $symixm = mod1($symix - 1, size(itp,$d))
+        $symixp = modrange($symix + 1, inds_itp[$d])
+        $symixm = modrange($symix - 1, inds_itp[$d])
     end
 end
 function define_indices_d{BC<:Union{InPlace,InPlaceQ}}(::Type{BSpline{Quadratic{BC}}}, d, pad)
@@ -58,11 +58,11 @@ function define_indices_d{BC<:Union{InPlace,InPlaceQ}}(::Type{BSpline{Quadratic{
     quote
         # ensure that all three ix_d, ixm_d, and ixp_d are in-bounds no matter
         # the value of pad
-        $symix = clamp(round(Int, $symx), 1, size(itp,$d))
+        $symix = clamp(round(Int, $symx), first(inds_itp[$d]), last(inds_itp[$d]))
         $symfx = $symx - $symix
         $symix += $pad # padding for oob coefficient
-        $symixp = min(size(itp,$d), $symix + 1)
-        $symixm = max(1, $symix - 1)
+        $symixp = min(last(inds_itp[$d]), $symix + 1)
+        $symixm = max(first(inds_itp[$d]), $symix - 1)
     end
 end
 

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -78,5 +78,7 @@ end
 lbound(etp::Extrapolation, d) = lbound(etp.itp, d)
 ubound(etp::Extrapolation, d) = ubound(etp.itp, d)
 size(etp::Extrapolation, d) = size(etp.itp, d)
+indices(etp::AbstractExtrapolation) = indices(etp.itp)
+indices(etp::AbstractExtrapolation, d) = indices(etp.itp, d)
 
 include("filled.jl")

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -241,6 +241,7 @@ function next_gen{CR,SITPT,X1,Deg,T}(::Type{ScaledIterator{CR,SITPT,X1,Deg,T}})
     quote
         sitp = iter.sitp
         itp = sitp.itp
+        inds_itp = indices(itp)
         if iter.nremaining > 0
             iter.nremaining -= 1
             iter.fx_1 += iter.dx_1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,2 +1,4 @@
 @inline sqr(x) = x*x
 @inline cub(x) = x*x*x
+
+modrange(x, r::AbstractUnitRange) = mod(x-first(r), length(r)) + first(r)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+OffsetArrays

--- a/test/b-splines/non1.jl
+++ b/test/b-splines/non1.jl
@@ -1,0 +1,93 @@
+module Non1Tests
+
+using Interpolations, OffsetArrays, AxisAlgorithms, Base.Test
+
+# At present, for a particular type of non-1 array you need to specialize this function
+function AxisAlgorithms.A_ldiv_B_md!(dest::OffsetArray, F, src::OffsetArray, dim::Integer, b::AbstractVector)
+    indsdim = indices(parent(src), dim)
+    indsF = indices(F)[2]
+    if indsF == indsdim
+        return A_ldiv_B_md!(parent(dest), F, parent(src), dim, b)
+    end
+    throw(DimensionMismatch("indices $(indices(parent(src))) do not match $(indices(F))"))
+end
+
+for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
+    f1(x) = sin((x-3)*2pi/9 - 1)
+    inds = -3:6
+    A1 = OffsetArray(Float64[f1(x) for x in inds], inds)
+
+    f2(x,y) = sin(x/10)*cos(y/6) + 0.1
+    xinds, yinds = -2:28,0:9
+    A2 = OffsetArray(Float64[f2(x,y) for x in xinds, y in yinds], xinds, yinds)
+
+    for GT in (OnGrid, OnCell), O in (Constant, Linear)
+        itp1 = @inferred(constructor(copier(A1), BSpline(O()), GT()))
+        @test @inferred(indices(itp1)) === indices(A1)
+
+        # test that we reproduce the values at on-grid points
+        for x = inds
+            @test itp1[x] ≈ f1(x)
+        end
+
+        itp2 = @inferred(constructor(copier(A2), BSpline(O()), GT()))
+        @test @inferred(indices(itp2)) === indices(A2)
+        for j = yinds, i = xinds
+            @test itp2[i,j] ≈ A2[i,j]
+        end
+    end
+
+    for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
+        itp1 = @inferred(constructor(copier(A1), BSpline(Quadratic(BC())), GT()))
+        @test @inferred(indices(itp1)) === indices(A1)
+
+        # test that we reproduce the values at on-grid points
+        inset = constructor == interpolate!
+        for x = first(inds)+inset:last(inds)-inset
+            @test itp1[x] ≈ f1(x)
+        end
+
+        itp2 = @inferred(constructor(copier(A2), BSpline(Quadratic(BC())), GT()))
+        @test @inferred(indices(itp2)) === indices(A2)
+        for j = first(yinds)+inset:last(yinds)-inset, i = first(xinds)+inset:last(xinds)-inset
+            @test itp2[i,j] ≈ A2[i,j]
+        end
+    end
+
+    for BC in (Flat,Line,Free,Periodic), GT in (OnGrid, OnCell)
+        itp1 = @inferred(constructor(copier(A1), BSpline(Cubic(BC())), GT()))
+        @test @inferred(indices(itp1)) === indices(A1)
+
+        # test that we reproduce the values at on-grid points
+        inset = constructor == interpolate!
+        for x = first(inds)+inset:last(inds)-inset
+            @test itp1[x] ≈ f1(x)
+        end
+
+        itp2 = @inferred(constructor(copier(A2), BSpline(Cubic(BC())), GT()))
+        @test @inferred(indices(itp2)) === indices(A2)
+        for j = first(yinds)+inset:last(yinds)-inset, i = first(xinds)+inset:last(xinds)-inset
+            @test itp2[i,j] ≈ A2[i,j]
+        end
+    end
+end
+
+let
+    f(x) = sin((x-3)*2pi/9 - 1)
+    inds = -7:2
+    A = OffsetArray(Float64[f(x) for x in inds], inds)
+    itp1 = interpolate!(copy(A), BSpline(Quadratic(InPlace())), OnCell())
+    for i in inds
+        @test itp1[i] ≈ A[i]
+    end
+
+    f(x,y) = sin(x/10)*cos(y/6) + 0.1
+    xinds, yinds = -2:28,0:9
+    A2 = OffsetArray(Float64[f(x,y) for x in xinds, y in yinds], xinds, yinds)
+    itp2 = interpolate!(copy(A2), BSpline(Quadratic(InPlace())), OnCell())
+    for j = yinds, i = xinds
+        @test itp2[i,j] ≈ A2[i,j]
+    end
+end
+
+end

--- a/test/b-splines/runtests.jl
+++ b/test/b-splines/runtests.jl
@@ -6,5 +6,6 @@ include("quadratic.jl")
 include("cubic.jl")
 include("mixed.jl")
 include("multivalued.jl")
+include("non1.jl")
 
 end

--- a/test/extrapolation/non1.jl
+++ b/test/extrapolation/non1.jl
@@ -1,0 +1,33 @@
+module ExtrapNon1
+
+using Base.Test, Interpolations, OffsetArrays
+
+f(x) = sin((x-3)*2pi/9 - 1)
+xinds = -3:6
+A = OffsetArray(Float64[f(x) for x in xinds], xinds)
+itpg = interpolate(A, BSpline(Linear()), OnGrid())
+
+schemes = (
+    Flat,
+    Linear,
+    Reflect,
+    Periodic
+)
+
+for etp in map(E -> extrapolate(itpg, E()), schemes), x in xinds
+    @test @inferred(getindex(etp, x)) ≈ A[x]
+end
+
+g(y) = (y/100)^3
+yinds = 2:5
+A = OffsetArray(Float64[f(x)*g(y) for x in xinds, y in yinds], xinds, yinds)
+itp2 = interpolate(A, BSpline(Linear()), OnGrid())
+
+for (etp2,E) in map(E -> (extrapolate(itp2, E()), E), schemes)
+    E == Periodic && continue  # g isn't periodic
+    for y in yinds, x in xinds
+        @test @inferred(getindex(etp2, x, y)) ≈ A[x, y]
+    end
+end
+
+end

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -89,3 +89,4 @@ end
 end
 
 include("type-stability.jl")
+include("non1.jl")

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -51,7 +51,7 @@ sitp32 = @inferred scale(interpolate(Float32[testfunction(x,y) for x in -5:.5:5,
 
 # Iteration
 itp = interpolate(rand(3,3,3), BSpline(Quadratic(Flat())), OnCell())
-knots = map(d->1:100:201, 1:3)
+knots = map(d->1:10:21, 1:3)
 sitp = @inferred scale(itp, knots...)
 function foo!(dest, sitp)
     i = 0


### PR DESCRIPTION
The master branch of Interpolations assumes that the input arrays start indexing at 1. Starting with julia-0.5, it's possible to support arrays that index over arbitrary `AbstractUnitRange`s. This PR appears to support such arrays. While not tested yet, I presume the first consumer of this functionality will be [ImageTransformations.jl](https://github.com/JuliaImages/ImageTransformations.jl/pull/9), where we use non-1 based indices to keep track of where pixels "really" are.

In theory, internally the most thorough way to do this would have been to rework how we apply padding: it might be somewhat more natural to pad a `1:n` range so that the internal padded version has indices `0:n+1` rather than `1:n+2`. (Among other things, that would ensure that `x = 2.2` would mean the same "physical" location no matter whether one was referring to the original or padded array.) However, that would make Interpolations strictly dependent on a package like [OffsetArrays](https://github.com/alsam/OffsetArrays.jl), and I wasn't sure whether people wanted that. So I decided to keep our current schemes and modify Interpolations so that OffsetArrays would be *supported* but not *required*.

One consequence of this decision is that any user of this functionality needs to extend `A_ldiv_B_md!` for whatever non1-array types (s)he wants to use. This seems necessary because our linear algebra infrastructure all assumes 1-based indices.

The point of having added benchmarks was to prepare for this PR, so...here are the regressions and improvements:
```julia
julia> regs = regressions(judge(minimum(pr), minimum(master)))
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "bsplines" => 4-element BenchmarkGroup([])

julia> leaves(regs)
30-element Array{Any,1}:
 (Any["bsplines","constant","1d_Constant()_OnGrid_construct"],TrialJudgement(-1.90% => invariant))       
 (Any["bsplines","constant","1d_Constant()_OnGrid_use"],TrialJudgement(+10.33% => regression))           
 (Any["bsplines","constant","3d_Constant()_OnCell_use"],TrialJudgement(+49.27% => regression))           
 (Any["bsplines","constant","2d_Constant()_OnGrid_construct"],TrialJudgement(-2.46% => invariant))       
 (Any["bsplines","constant","1d_Constant()_OnCell_use"],TrialJudgement(+9.89% => regression))            
 (Any["bsplines","constant","2d_Constant()_OnCell_use"],TrialJudgement(+9.29% => regression))            
 (Any["bsplines","constant","2d_Constant()_OnGrid_use"],TrialJudgement(+8.99% => regression))            
 (Any["bsplines","constant","1d_Constant()_OnCell_construct"],TrialJudgement(-1.63% => invariant))       
 (Any["bsplines","constant","3d_Constant()_OnGrid_use"],TrialJudgement(+48.81% => regression))           
 (Any["bsplines","constant","2d_Constant()_OnCell_construct"],TrialJudgement(-0.09% => invariant))       
 (Any["bsplines","cubic","2d_Quadratic(Flat())_OnCell_use"],TrialJudgement(+5.31% => regression))        
 (Any["bsplines","cubic","2d_Quadratic(Flat())_OnGrid_use"],TrialJudgement(+5.26% => regression))        
 (Any["bsplines","linear","2d_Linear()_OnGrid_construct"],TrialJudgement(-2.20% => invariant))           
 (Any["bsplines","linear","1d_Linear()_OnGrid_use"],TrialJudgement(+6.37% => regression))                
 (Any["bsplines","linear","1d_Linear()_OnGrid_construct"],TrialJudgement(-3.05% => invariant))           
 (Any["bsplines","linear","1d_Linear()_OnCell_construct"],TrialJudgement(-0.46% => invariant))           
 (Any["bsplines","linear","2d_Linear()_OnCell_use"],TrialJudgement(+5.81% => regression))                
 (Any["bsplines","linear","3d_Linear()_OnCell_use"],TrialJudgement(+15.79% => regression))               
 (Any["bsplines","linear","2d_Linear()_OnCell_construct"],TrialJudgement(-3.15% => invariant))           
 (Any["bsplines","linear","2d_Linear()_OnGrid_use"],TrialJudgement(+8.27% => regression))                
 (Any["bsplines","linear","3d_Linear()_OnGrid_use"],TrialJudgement(+14.46% => regression))               
 (Any["bsplines","quadratic","3d_Quadratic(Free())_OnCell_use"],TrialJudgement(+6.48% => regression))    
 (Any["bsplines","quadratic","3d_Quadratic(Free())_OnGrid_use"],TrialJudgement(+6.74% => regression))    
 (Any["bsplines","quadratic","3d_Quadratic(Periodic())_OnGrid_use"],TrialJudgement(+6.65% => regression))
 (Any["bsplines","quadratic","3d_Quadratic(Periodic())_OnCell_use"],TrialJudgement(+6.68% => regression))
 (Any["bsplines","quadratic","2d_Quadratic(InPlace())_OnCell_use"],TrialJudgement(+21.72% => regression))
 (Any["bsplines","quadratic","3d_Quadratic(InPlace())_OnCell_use"],TrialJudgement(+9.35% => regression)) 
 (Any["bsplines","quadratic","3d_Quadratic(Reflect())_OnGrid_use"],TrialJudgement(+6.81% => regression)) 
 (Any["bsplines","quadratic","3d_Quadratic(Line())_OnCell_use"],TrialJudgement(+6.32% => regression))    
 (Any["bsplines","quadratic","3d_Quadratic(Line())_OnGrid_use"],TrialJudgement(+30.08% => regression))   

julia> imps = improvements(judge(minimum(pr), minimum(master)))
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "bsplines" => 2-element BenchmarkGroup([])

julia> leaves(imps)
32-element Array{Any,1}:
 (Any["bsplines","cubic","1d_Quadratic(Line())_OnGrid_construct"],TrialJudgement(-2.93% => invariant))          
 (Any["bsplines","cubic","1d_Quadratic(Line())_OnCell_construct"],TrialJudgement(-3.61% => invariant))          
 (Any["bsplines","cubic","1d_Quadratic(Flat())_OnCell_construct"],TrialJudgement(-3.16% => invariant))          
 (Any["bsplines","cubic","1d_Quadratic(Flat())_OnGrid_construct"],TrialJudgement(-5.22% => improvement))        
 (Any["bsplines","cubic","1d_Quadratic(Periodic())_OnCell_construct"],TrialJudgement(-2.30% => invariant))      
 (Any["bsplines","cubic","1d_Quadratic(Line())_OnCell_use"],TrialJudgement(-10.98% => improvement))             
 (Any["bsplines","cubic","2d_Quadratic(Periodic())_OnGrid_use"],TrialJudgement(-5.14% => improvement))          
 (Any["bsplines","cubic","2d_Quadratic(Free())_OnCell_use"],TrialJudgement(-5.82% => improvement))              
 (Any["bsplines","cubic","1d_Quadratic(Free())_OnCell_construct"],TrialJudgement(-2.52% => invariant))          
 (Any["bsplines","cubic","1d_Quadratic(Free())_OnGrid_construct"],TrialJudgement(-1.42% => invariant))          
 (Any["bsplines","cubic","1d_Quadratic(Periodic())_OnGrid_construct"],TrialJudgement(-1.76% => invariant))      
 (Any["bsplines","quadratic","1d_Quadratic(Line())_OnGrid_construct"],TrialJudgement(-1.91% => invariant))      
 (Any["bsplines","quadratic","3d_Quadratic(Line())_OnCell_construct"],TrialJudgement(-14.48% => improvement))   
 (Any["bsplines","quadratic","1d_Quadratic(Line())_OnCell_construct"],TrialJudgement(-4.32% => invariant))      
 (Any["bsplines","quadratic","2d_Quadratic(Reflect())_OnCell_construct"],TrialJudgement(-1.22% => invariant))   
 (Any["bsplines","quadratic","1d_Quadratic(Flat())_OnCell_construct"],TrialJudgement(-13.18% => improvement))   
 (Any["bsplines","quadratic","1d_Quadratic(Periodic())_OnGrid_use"],TrialJudgement(-9.00% => improvement))      
 (Any["bsplines","quadratic","1d_Quadratic(Reflect())_OnGrid_construct"],TrialJudgement(-2.64% => invariant))   
 (Any["bsplines","quadratic","1d_Quadratic(Flat())_OnGrid_construct"],TrialJudgement(-2.44% => invariant))      
 (Any["bsplines","quadratic","1d_Quadratic(Periodic())_OnCell_construct"],TrialJudgement(-2.71% => invariant))  
 (Any["bsplines","quadratic","3d_Quadratic(InPlaceQ())_OnCell_construct"],TrialJudgement(-5.24% => improvement))
 (Any["bsplines","quadratic","1d_Quadratic(Line())_OnCell_use"],TrialJudgement(-9.15% => improvement))          
 (Any["bsplines","quadratic","3d_Quadratic(Flat())_OnCell_construct"],TrialJudgement(-5.84% => improvement))    
 (Any["bsplines","quadratic","2d_Quadratic(Flat())_OnCell_construct"],TrialJudgement(-1.72% => invariant))      
 (Any["bsplines","quadratic","1d_Quadratic(InPlace())_OnCell_construct"],TrialJudgement(-11.11% => improvement))
 (Any["bsplines","quadratic","1d_Quadratic(Free())_OnCell_construct"],TrialJudgement(-4.40% => invariant))      
 (Any["bsplines","quadratic","2d_Quadratic(InPlaceQ())_OnCell_use"],TrialJudgement(-10.85% => improvement))     
 (Any["bsplines","quadratic","3d_Quadratic(Reflect())_OnCell_construct"],TrialJudgement(-1.90% => invariant))   
 (Any["bsplines","quadratic","1d_Quadratic(Free())_OnGrid_construct"],TrialJudgement(-5.78% => improvement))    
 (Any["bsplines","quadratic","1d_Quadratic(Periodic())_OnGrid_construct"],TrialJudgement(-3.06% => invariant))  
 (Any["bsplines","quadratic","3d_Quadratic(Flat())_OnCell_use"],TrialJudgement(-5.06% => improvement))          
 (Any["bsplines","quadratic","1d_Quadratic(Reflect())_OnCell_construct"],TrialJudgement(-3.70% => invariant))   
```
Most of this is probably noise, but I suspect the regressions on `Constant` (esp. for 3d) are real. If anyone is concerned about that, I suspect the next step would be to turn `map_repeat` into a `@generated` function. I'd be interested in knowing how folks feel about the "cleanliness" vs "performance" tradeoff in this case.
