### PR TITLE
use ShowItLikeYouBuildIt for Base.show

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.5
 
+ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
 AxisAlgorithms

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -97,5 +97,6 @@ include("gridded/gridded.jl")
 include("extrapolation/extrapolation.jl")
 include("scaling/scaling.jl")
 include("utils.jl")
+include("io.jl")
 
 end # module

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,83 @@
+using ShowItLikeYouBuildIt
+
+Base.summary(A::AbstractInterpolation) = summary_build(A)
+
+function ShowItLikeYouBuildIt.showarg{T,N,TW,ST,GT}(io::IO, A::BSplineInterpolation{T,N,TW,ST,GT})
+    print(io, "interpolate(")
+    showarg(io, A.coefs)
+    print(io, ", ")
+    _showtypeparam(io, ST)
+    print(io, ", ")
+    _showtypeparam(io, GT)
+    print(io, ')')
+end
+
+function ShowItLikeYouBuildIt.showarg{T,N,TC,ST,K}(io::IO, A::GriddedInterpolation{T,N,TC,ST,K})
+    print(io, "interpolate(")
+    _showknots(io, A.knots)
+    print(io, ", ")
+    showarg(io, A.coefs)
+    print(io, ", ")
+    _showtypeparam(io, ST)
+    print(io, ')')
+end
+
+_showknots(io, A) = showarg(io, A)
+function _showknots{N}(io, tup::NTuple{N,Any})
+    print(io, '(')
+    for (i, A) in enumerate(tup)
+        showarg(io, A)
+        i < N && print(io, ',')
+    end
+    N == 1 && print(io, ',')
+    print(io, ')')
+end
+
+function ShowItLikeYouBuildIt.showarg(io::IO, A::ScaledInterpolation)
+    print(io, "scale(")
+    showarg(io, A.itp)
+    print(io, ", ", A.ranges, ')')
+end
+
+function ShowItLikeYouBuildIt.showarg{T,N,TI,IT,GT,ET}(io::IO, A::Extrapolation{T,N,TI,IT,GT,ET})
+    print(io, "extrapolate(")
+    showarg(io, A.itp)
+    print(io, ", ")
+    _showtypeparam(io, ET)
+    print(io, ')')
+end
+
+function ShowItLikeYouBuildIt.showarg{T,N,TI,IT,GT}(io::IO, A::FilledExtrapolation{T,N,TI,IT,GT})
+    print(io, "extrapolate(")
+    showarg(io, A.itp)
+    print(io, ", ", A.fillvalue, ')')
+end
+
+_showtypeparam{T}(io, ::Type{T}) =
+    print(io, T.name.name, "()")
+_showtypeparam{T}(io, ::Type{Quadratic{T}}) =
+    print(io, "Quadratic(", T.name.name, "())")
+_showtypeparam{T}(io, ::Type{Cubic{T}}) =
+    print(io, "Cubic(",     T.name.name, "())")
+
+function _showtypeparam{T}(io, ::Type{BSpline{T}})
+    print(io, "BSpline(")
+    _showtypeparam(io, T)
+    print(io, ')')
+end
+
+function _showtypeparam{T}(io, ::Type{Gridded{T}})
+    print(io, "Gridded(")
+    _showtypeparam(io, T)
+    print(io, ')')
+end
+
+function _showtypeparam{TTup<:Tuple}(io, types::Type{TTup})
+    print(io, '(')
+    N = length(types.types)
+    for (i, T) in enumerate(types.types)
+        _showtypeparam(io, T)
+        i < N && print(io, ", ")
+    end
+    print(io, ')')
+end

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,0 +1,77 @@
+module IOTests
+
+using Base.Test
+using Interpolations
+
+SPACE = if VERSION < v"0.6.0-dev.2505" # julia PR #20288
+    ""
+else
+    " "
+end
+
+@testset "BSpline" begin
+    A = rand(8,20)
+
+    itp = interpolate(A, BSpline(Constant()), OnCell())
+    @test summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant()), OnCell()) with element type Float64"
+
+    itp = interpolate(A, BSpline(Constant()), OnGrid())
+    @test summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant()), OnGrid()) with element type Float64"
+
+    itp = interpolate(A, BSpline(Linear()), OnGrid())
+    @test summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Linear()), OnGrid()) with element type Float64"
+
+    itp = interpolate(A, BSpline(Quadratic(Reflect())), OnCell())
+    @test summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Quadratic(Reflect())), OnCell()) with element type Float64"
+
+    itp = interpolate(A, (BSpline(Linear()), NoInterp()), OnGrid())
+    @test summary(itp) == "8×20 interpolate(::Array{Float64,2}, (BSpline(Linear()), NoInterp()), OnGrid()) with element type Float64"
+
+    itp = interpolate!(copy(A), BSpline(Quadratic(InPlace())), OnCell())
+    @test summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Quadratic(InPlace())), OnCell()) with element type Float64"
+end
+
+@testset "Gridded" begin
+    A = rand(20)
+    A_x = collect(1.0:2.0:40.0)
+    knots = (A_x,)
+    itp = interpolate(knots, A, Gridded(Linear()))
+    @test summary(itp) == "20-element interpolate((::Array{Float64,1},), ::Array{Float64,1}, Gridded(Linear())) with element type Float64"
+
+    A = rand(8,20)
+    knots = ([x^2 for x = 1:8], [0.2y for y = 1:20])
+    itp = interpolate(knots, A, Gridded(Linear()))
+    @test summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, Gridded(Linear())) with element type Float64"
+
+    itp = interpolate(knots, A, (Gridded(Linear()),Gridded(Constant())))
+    @test summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, (Gridded(Linear()), Gridded(Constant()))) with element type Float64"
+end
+
+@testset "scaled" begin
+    itp = interpolate(1:1.0:10, BSpline(Linear()), OnGrid())
+    sitp = scale(itp, -3:.5:1.5)
+    @test summary(sitp) == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear()), OnGrid()), (-3.0:0.5:1.5,)) with element type Float64"
+
+    gauss(phi, mu, sigma) = exp(-(phi-mu)^2 / (2sigma)^2)
+    testfunction(x,y) = gauss(x, 0.5, 4) * gauss(y, -.5, 2)
+    xs = -5:.5:5
+    ys = -4:.2:4
+    zs = Float64[testfunction(x,y) for x in xs, y in ys]
+    itp2 = interpolate(zs, BSpline(Quadratic(Flat())), OnGrid())
+    sitp2 = scale(itp2, xs, ys)
+    @test summary(sitp2) == "21×41 scale(interpolate(::Array{Float64,2}, BSpline(Quadratic(Flat())), OnGrid()), (-5.0:0.5:5.0,$SPACE-4.0:0.2:4.0)) with element type Float64"
+end
+
+@testset "Extrapolation" begin
+    A = rand(8,20)
+
+    itpg = interpolate(A, BSpline(Linear()), OnGrid())
+    etpg = extrapolate(itpg, Flat())
+    @test summary(etpg) == "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear()), OnGrid()), Flat()) with element type Float64"
+
+    etpf = extrapolate(itpg, NaN)
+    @test summary(etpf) == "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear()), OnGrid()), NaN) with element type Float64"
+end
+
+
+end # Module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,8 @@ include("typing.jl")
 
 include("issues/runtests.jl")
 
+include("io.jl")
+
 end
 
 nothing


### PR DESCRIPTION
This PR makes all `AbstractInterpolation` render their summary string in the REPL using the package [JuliaArrays/ShowItLikeYouBuildIt.jl](https://github.com/JuliaArrays/ShowItLikeYouBuildIt.jl).
This is a display-style that is used throughout the new Image ecosystem and makes the `summary` a little more informative for nested `AbstractArray` types.

for example, with this PR the types render in the REPL as follows:

```julia
julia> itp = interpolate(1:1.0:10, BSpline(Linear()), OnGrid())
10-element interpolate(::Array{Float64,1}, BSpline(Linear()), OnGrid()) with element type Float64:
  1.0
  2.0
  ⋮  
  9.0
 10.0

julia> sitp = scale(itp, -3:.5:1.5)
10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear()), OnGrid()), (-3.0:0.5:1.5,)) with element type Float64:
  9.0
 11.0
  ⋮  
 25.0
 27.0

julia> etp = extrapolate(sitp, Flat())
10-element extrapolate(scale(interpolate(::Array{Float64,1}, BSpline(Linear()), OnGrid()), (-3.0:0.5:1.5,)), Flat()) with element type Float64:
  9.0
 10.0
  ⋮  
 10.0
 10.0
```

instead of what `master` does currently (scroll right to see the whole printout):

```julia
julia> itp = interpolate(1:1.0:10, BSpline(Linear()), OnGrid())
10-element Interpolations.BSplineInterpolation{Float64,1,Array{Float64,1},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,0}:
  1.0
  2.0
  ⋮
  9.0
 10.0

julia> sitp = scale(itp, -3:.5:1.5)
10-element Interpolations.ScaledInterpolation{Float64,1,Interpolations.BSplineInterpolation{Float64,1,Array{Float64,1},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,0},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,Tuple{FloatRange{Float64}}}:
  9.0
 11.0
  ⋮
 25.0
 27.0

julia> etp = extrapolate(sitp, Flat())
10-element Interpolations.Extrapolation{Float64,1,Interpolations.ScaledInterpolation{Float64,1,Interpolations.BSplineInterpolation{Float64,1,Array{Float64,1},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,0},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,Tuple{FloatRange{Float64}}},Interpolations.BSpline{Interpolations.Linear},Interpolations.OnGrid,Interpolations.Flat}:
  9.0
 10.0
  ⋮
 10.0
 10.0
```

See the added tests for more examples.

## Context

@timholy and I were thinking about ways to make the REPL printout of interpolations and extrapolations a little more readable (see https://github.com/JuliaImages/ImageTransformations.jl/pull/13#issuecomment-294348743). For example a type that we are working with uses some extrapolation internally and thus the summary string gets really out of hand:

![more text please](https://cloud.githubusercontent.com/assets/10854026/25064801/78a1b96a-2202-11e7-8de5-8b4d3e968c93.png)

with this change it looks like this (don't mind the difference in the image preview; unrelated):

![nice](https://cloud.githubusercontent.com/assets/10854026/25072675/46856642-22d5-11e7-96d8-215ab67acfd1.png)
