### PR TITLE
Simplify inference's job on scaling infrastructure

### DIFF
--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -86,8 +86,12 @@ end
 # thats why we use this @noinline fence
 @noinline _promote_mul(a,b) = Base.promote_op(@functorize(*), a, b)
 
-@noinline function getindex_return_type{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad}(::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}, argtypes)
+@noinline function getindex_return_type{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad}(::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}, argtypes::Tuple)
     reduce(_promote_mul, eltype(TCoefs), argtypes)
+end
+
+function getindex_return_type{T,N,TCoefs,IT<:DimSpec{BSpline},GT<:DimSpec{GridType},Pad,I}(::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}, ::Type{I})
+    _promote_mul(eltype(TCoefs), I)
 end
 
 @generated function gradient!{T,N}(g::AbstractVector, itp::BSplineInterpolation{T,N}, xs::Number...)

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -55,6 +55,12 @@ sitp32 = @inferred scale(interpolate(Float32[testfunction(x,y) for x in -5:.5:5,
 itp = interpolate(rand(3,3,3), BSpline(Quadratic(Flat())), OnCell())
 knots = map(d->1:10:21, 1:3)
 sitp = @inferred scale(itp, knots...)
+
+iter = @inferred(eachvalue(sitp))
+state = @inferred(start(iter))
+@test !(@inferred(done(iter, state)))
+val, state = @inferred(next(iter, state))
+
 function foo!(dest, sitp)
     i = 0
     for s in eachvalue(sitp)


### PR DESCRIPTION
There seems to be a bug in Julia 0.5's inference (fixed on 0.6) that makes it vulnerable to the order in which functions are compiled. One consequence is that while the tests pass when run in the "standard" way, if you navigate to the `test/scaling` folder then in a fresh julia session one gets
```julia
$ julia                                                             
               _                                                                                                      
   _       _ _(_)_     |  A fresh approach to technical computing                                                             
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org                                                            
   _ _   _| |_  __ _   |  Type "?help" for help.                                                                              
  | | | | | | |/ _` |  |                                                                                                               
  | | |_| | | | (_| |  |  Version 0.5.1 (2017-03-05 13:25 UTC)                                                                         
 _/ |\__'_|_|_|\__'_|  |                                                                                                               
|__/                   |  x86_64-linux-gnu                                                                                                        
                                                                                                                                                  
julia> include("runtests.jl")
INFO: Recompiling stale cache file /home/tim/.julia/lib/v0.5/Interpolations.ji for module Interpolations.                                         
Test Failed                                                                                                                                                   
  Expression: @elapsed(foo!(rfoo,sitp)) < @elapsed(bar!(rbar,sitp))                                                                                           
   Evaluated: 0.001736163 < 0.000427983                                                                                                                                     
ERROR: LoadError: LoadError: There was an error during testing                                                                                                              
 in record(::Base.Test.FallbackTestSet, ::Base.Test.Fail) at ./test.jl:397                                                                                                  
 in do_test(::Base.Test.Returned, ::Expr) at ./test.jl:281
 in include_from_node1(::String) at ./loading.jl:488 (repeats 2 times)
while loading /home/tim/.julia/v0.5/Interpolations/test/scaling/scaling.jl, in expression starting on line 231
while loading /home/tim/.julia/v0.5/Interpolations/test/scaling/runtests.jl, in expression starting on line 1
```
The performance hit---purely due to failure of inference---is quite large.

This PR tries to simplify inference's task.