### PR TITLE
Faster extrapolation

### DIFF
--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -38,14 +38,23 @@ padding(itp::AbstractInterpolation) = padding(typeof(itp))
 padextract(pad::Integer, d) = pad
 padextract(pad::Tuple{Vararg{Integer}}, d) = pad[d]
 
-lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d) =
+lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d::Integer) =
     first(indices(itp, d))
-ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d) =
+ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d::Integer) =
     last(indices(itp, d))
-lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d) =
+lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d::Integer) =
     first(indices(itp, d)) - 0.5
-ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d) =
+ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d::Integer) =
     last(indices(itp, d))+0.5
+
+lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d, inds) =
+    first(inds)
+ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnGrid}, d, inds) =
+    last(inds)
+lbound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d, inds) =
+    first(inds) - 0.5
+ubound{T,N,TCoefs,IT}(itp::BSplineInterpolation{T,N,TCoefs,IT,OnCell}, d, inds) =
+    last(inds)+0.5
 
 count_interp_dims{T,N,TCoefs,IT<:DimSpec{InterpolationType},GT<:DimSpec{GridType},pad}(::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,pad}}, n) = count_interp_dims(IT, n)
 

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -50,6 +50,7 @@ and indices. The heavy lifting is done by the `extrap_prep` function; see
 function getindex_impl{T,N,ITPT,IT,GT,ET}(etp::Type{Extrapolation{T,N,ITPT,IT,GT,ET}}, xs...)
     coords = [Symbol("xs_",d) for d in 1:N]
     quote
+        $(Expr(:meta, :inline))
         @nexprs $N d->(xs_d = xs[d])
         $(extrap_prep(ET, Val{N}()))
         etp.itp[$(coords...)]
@@ -66,6 +67,7 @@ checkbounds(::AbstractExtrapolation,I...) = nothing
 function gradient!_impl{T,N,ITPT,IT,GT,ET}(g, etp::Type{Extrapolation{T,N,ITPT,IT,GT,ET}}, xs...)
     coords = [Symbol("xs_", d) for d in 1:N]
     quote
+        $(Expr(:meta, :inline))
         @nexprs $N d->(xs_d = xs[d])
         $(extrap_prep(Val{:gradient}(), ET, Val{N}()))
         gradient!(g, etp.itp, $(coords...))

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -81,8 +81,10 @@ end
 
 lbound(etp::Extrapolation, d) = lbound(etp.itp, d)
 ubound(etp::Extrapolation, d) = ubound(etp.itp, d)
+lbound(etp::Extrapolation, d, inds) = lbound(etp.itp, d, inds)
+ubound(etp::Extrapolation, d, inds) = ubound(etp.itp, d, inds)
 size(etp::Extrapolation, d) = size(etp.itp, d)
-indices(etp::AbstractExtrapolation) = indices(etp.itp)
+@inline indices(etp::AbstractExtrapolation) = indices(etp.itp)
 indices(etp::AbstractExtrapolation, d) = indices(etp.itp, d)
 
 include("filled.jl")

--- a/src/extrapolation/filled.jl
+++ b/src/extrapolation/filled.jl
@@ -26,7 +26,8 @@ function getindex_impl{T,N,ITP,IT,GT,FT}(fitp::Type{FilledExtrapolation{T,N,ITP,
        $meta
        # Check to see if we're in the extrapolation region, i.e.,
        # out-of-bounds in an index
-       @nexprs $N d->((args[d] < lbound(fitp,d) || args[d] > ubound(fitp, d))) && return convert($Tret, fitp.fillvalue)::$Tret
+       inds_etp = indices(fitp)
+       @nexprs $N d->((args[d] < lbound(fitp, d, inds_etp[d]) || args[d] > ubound(fitp, d, inds_etp[d]))) && return convert($Tret, fitp.fillvalue)::$Tret
        # In the interpolation region
        return convert($Tret, getindex(fitp.itp,args...))::$Tret
    end
@@ -41,3 +42,5 @@ getindex{T}(fitp::FilledExtrapolation{T,1}, x::Number, y::Int) = y == 1 ? fitp[x
 
 lbound(etp::FilledExtrapolation, d) = lbound(etp.itp, d)
 ubound(etp::FilledExtrapolation, d) = ubound(etp.itp, d)
+lbound(etp::FilledExtrapolation, d, inds) = lbound(etp.itp, d, inds)
+ubound(etp::FilledExtrapolation, d, inds) = ubound(etp.itp, d, inds)

--- a/src/extrapolation/flat.jl
+++ b/src/extrapolation/flat.jl
@@ -1,16 +1,16 @@
 function extrap_prep{N,d}(::Type{Flat}, ::Val{N}, ::Val{d})
     xs_d = Symbol("xs_", d)
-    :($xs_d = clamp($xs_d, lbound(etp, $d), ubound(etp, $d)))
+    :($xs_d = clamp($xs_d, lbound(etp, $d, inds_etp[$d]), ubound(etp, $d, inds_etp[$d])))
 end
 
 function extrap_prep{N,d}(::Type{Flat}, ::Val{N}, ::Val{d}, ::Val{:lo})
     xs_d = Symbol("xs_", d)
-    :($xs_d = max($xs_d, lbound(etp, $d)))
+    :($xs_d = max($xs_d, lbound(etp, $d, inds_etp[$d])))
 end
 
 function extrap_prep{N,d}(::Type{Flat}, ::Val{N}, ::Val{d}, ::Val{:hi})
     xs_d = Symbol("xs_", d)
-    :($xs_d = min($xs_d, ubound(etp, $d)))
+    :($xs_d = min($xs_d, ubound(etp, $d, inds_etp[$d])))
 end
 
 function extrap_prep{N,d}(::Val{:gradient}, ::Type{Flat}, ::Val{N}, ::Val{d}, ::Val{:lo})
@@ -18,8 +18,8 @@ function extrap_prep{N,d}(::Val{:gradient}, ::Type{Flat}, ::Val{N}, ::Val{d}, ::
     xs_d = coords[d]
 
     quote
-        if $xs_d < lbound(etp, $d)
-            $xs_d = lbound(etp, $d)
+        if $xs_d < lbound(etp, $d, inds_etp[$d])
+            $xs_d = lbound(etp, $d, inds_etp[$d])
             gradient!(g, etp.itp, $(coords...))
             g[$d] = 0
             return g
@@ -32,8 +32,8 @@ function extrap_prep{N,d}(::Val{:gradient}, ::Type{Flat}, ::Val{N}, ::Val{d}, ::
     xs_d = coords[d]
 
     quote
-        if $xs_d > ubound(etp, $d)
-            $xs_d = ubound(etp, $d)
+        if $xs_d > ubound(etp, $d, inds_etp[$d])
+            $xs_d = ubound(etp, $d, inds_etp[$d])
             gradient!(g, etp.itp, $(coords...))
             g[$d] = 0
             return g

--- a/src/extrapolation/linear.jl
+++ b/src/extrapolation/linear.jl
@@ -2,8 +2,8 @@ function extrap_prep{N,d}(::Type{Linear}, ::Val{N}, ::Val{d}, ::Val{:lo})
     coords = [Symbol("xs_", k) for k in 1:N]
     xs_d = coords[d]
     quote
-        if $xs_d < lbound(etp.itp, $d)
-            $xs_d = lbound(etp.itp, $d)
+        if $xs_d < lbound(etp.itp, $d, inds_etp[$d])
+            $xs_d = lbound(etp.itp, $d, inds_etp[$d])
             return etp[$(coords...)] + gradient(etp, $(coords...))[$d] * (xs[$d] - $xs_d)
         end
     end
@@ -12,8 +12,8 @@ function extrap_prep{N,d}(::Type{Linear}, ::Val{N}, ::Val{d}, ::Val{:hi})
     coords = [Symbol("xs_", k) for k in 1:N]
     xs_d = coords[d]
     quote
-        if $xs_d > ubound(etp, $d)
-            $xs_d = ubound(etp, $d)
+        if $xs_d > ubound(etp, $d, inds_etp[$d])
+            $xs_d = ubound(etp, $d, inds_etp[$d])
             return etp[$(coords...)] + gradient(etp, $(coords...))[$d] * (xs[$d] - $xs_d)
         end
     end

--- a/src/extrapolation/periodic.jl
+++ b/src/extrapolation/periodic.jl
@@ -5,14 +5,14 @@ Translate x into the domain [lbound, ubound] my means of `mod()`
 """
 function extrap_prep_dim(::Type{Periodic}, d)
     xs_d = Symbol("xs_", d)
-    :($xs_d = mod(xs[$d] - lbound(etp.itp, $d), ubound(etp.itp, $d) - lbound(etp.itp, $d)) + lbound(etp.itp, $d))
+    :($xs_d = mod(xs[$d] - lbound(etp.itp, $d, inds_etp[$d]), ubound(etp.itp, $d, inds_etp[$d]) - lbound(etp.itp, $d, inds_etp[$d])) + lbound(etp.itp, $d, inds_etp[$d]))
 end
 
 extrap_prep{N,d}(::Type{Periodic}, ::Val{N}, ::Val{d}) = extrap_prep_dim(Periodic, d)
 function extrap_prep{N,d}(::Type{Periodic}, ::Val{N}, ::Val{d}, ::Val{:lo})
     xs_d = Symbol("xs_", d)
     quote
-        if $xs_d < lbound(etp.itp, $d)
+        if $xs_d < lbound(etp.itp, $d, inds_etp[$d])
             $(extrap_prep_dim(Periodic, d))
         end
     end
@@ -20,7 +20,7 @@ end
 function extrap_prep{N,d}(::Type{Periodic}, ::Val{N}, ::Val{d}, ::Val{:hi})
     xs_d = Symbol("xs_", d)
     quote
-        if $xs_d > ubound(etp.itp, d)
+        if $xs_d > ubound(etp.itp, d, inds_etp[$d])
             $(extrap_prep_dim(Periodic, d))
         end
     end

--- a/src/extrapolation/reflect.jl
+++ b/src/extrapolation/reflect.jl
@@ -7,8 +7,8 @@ Next, if x is now in the upper part of this ''double-domain´´, reflect over th
 function extrap_prep_dim(::Type{Reflect}, d)
     xs_d = Symbol("xs_", d)
     quote
-        start = lbound(etp.itp, $d)
-        width = ubound(etp.itp, $d) - start
+        start = lbound(etp.itp, $d, inds_etp[$d])
+        width = ubound(etp.itp, $d, inds_etp[$d]) - start
 
         $xs_d = mod($xs_d - start, 2width) + start
         $xs_d > start + width && (xs_d = start + width - $xs_d)
@@ -18,9 +18,9 @@ end
 extrap_prep{N,d}(::Type{Reflect}, ::Val{N}, ::Val{d}) = extrap_prep_dim(Reflect, d)
 function extrap_prep{N,d}(::Type{Reflect}, ::Val{N}, ::Val{d}, ::Val{:lo})
     xs_d = Symbol("xs_", d)
-    :($xs_d < lbound(etp.itp, $d) && $(extrap_prep_dim(Reflect, d)))
+    :($xs_d < lbound(etp.itp, $d, inds_etp[$d]) && $(extrap_prep_dim(Reflect, d)))
 end
 function extrap_prep{N,d}(::Type{Reflect}, ::Val{N}, ::Val{d}, ::Val{:hi})
     xs_d = Symbol("xs_", d)
-    :($xs_d > ubound(etp.itp, $d) && $(extrap_prep_dim(Reflect, d)))
+    :($xs_d > ubound(etp.itp, $d, inds_etp[$d]) && $(extrap_prep_dim(Reflect, d)))
 end

--- a/src/extrapolation/throw.jl
+++ b/src/extrapolation/throw.jl
@@ -1,14 +1,14 @@
 function extrap_prep{N,d}(::Type{Throw}, ::Val{N}, ::Val{d})
     xsym = Symbol("xs_", d)
-    :(lbound(etp, $d) <= $xsym <= ubound(etp, $d) || throw(BoundsError()))
+    :(lbound(etp, $d, inds_etp[$d]) <= $xsym <= ubound(etp, $d, inds_etp[$d]) || throw(BoundsError()))
 end
 
 function extrap_prep{N,d}(::Type{Throw}, ::Val{N}, ::Val{d}, ::Val{:lo})
     xsym = Symbol("xs_", d)
-    :(lbound(etp, $d) <= $xsym || throw(BoundsError()))
+    :(lbound(etp, $d, inds_etp[$d]) <= $xsym || throw(BoundsError()))
 end
 
 function extrap_prep{N,d}(::Type{Throw}, ::Val{N}, ::Val{d}, ::Val{:hi})
     xsym = Symbol("xs_", d)
-    :($xsym <= ubound(etp, $d) || throw(BoundsError()))
+    :($xsym <= ubound(etp, $d, inds_etp[$d]) || throw(BoundsError()))
 end

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -64,6 +64,8 @@ end
 
 lbound(itp::GriddedInterpolation, d) = itp.knots[d][1]
 ubound(itp::GriddedInterpolation, d) = itp.knots[d][end]
+lbound(itp::GriddedInterpolation, d, inds) = itp.knots[d][1]
+ubound(itp::GriddedInterpolation, d, inds) = itp.knots[d][end]
 
 include("constant.jl")
 include("linear.jl")

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -50,6 +50,15 @@ lbound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnCell}, d) = 1 <= d <
 ubound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnGrid}, d) = 1 <= d <= N ? sitp.ranges[d][end] : throw(BoundsError())
 ubound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnCell}, d) = 1 <= d <= N ? sitp.ranges[d][end] + boundstep(sitp.ranges[d]) : throw(BoundsError())
 
+lbound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnGrid}, d, inds) =
+    sitp.ranges[d][1]
+lbound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnCell}, d, inds) =
+    sitp.ranges[d][1] - boundstep(sitp.ranges[d])
+ubound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnGrid}, d, inds) =
+    sitp.ranges[d][end]
+ubound{T,N,ITPT,IT}(sitp::ScaledInterpolation{T,N,ITPT,IT,OnCell}, d, inds) =
+    sitp.ranges[d][end] + boundstep(sitp.ranges[d])
+
 boundstep(r::StepRange) = r.step / 2
 boundstep(r::UnitRange) = 1//2
 


### PR DESCRIPTION
I happened to notice that extrapolation is quite a lot slower than interpolation:
```julia
julia> using BenchmarkTools, Interpolations

julia> img = rand(3,3,3);

julia> itp = interpolate(img, BSpline(Linear()), OnGrid());

julia> etp = extrapolate(itp, Flat());

julia> @benchmark $itp[2.2,2.2,2.2] seconds=1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     20.111 ns (0.00% GC)
  median time:      20.616 ns (0.00% GC)
  mean time:        20.820 ns (0.00% GC)
  maximum time:     38.106 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     997

julia> @benchmark $etp[2.2,2.2,2.2] seconds=1
BenchmarkTools.Trial: 
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     63.526 ns (0.00% GC)
  median time:      63.929 ns (0.00% GC)
  mean time:        66.641 ns (1.99% GC)
  maximum time:     2.312 μs (96.59% GC)
  --------------
  samples:          10000
  evals/sample:     980
```
This slowness doesn't seem inevitable, because the amount of "work" (computation) performed by extrapolation is quite minor compared to the work done by interpolation:
```julia
julia> Interpolations.getindex_impl(typeof(etp))
quote  # /home/tim/.julia/v0.5/Interpolations/src/extrapolation/extrapolation.jl, line 53:
    @nexprs 3 (d->begin  # /home/tim/.julia/v0.5/Interpolations/src/extrapolation/extrapolation.jl, line 53:
                xs_d = xs[d]
            end) # /home/tim/.julia/v0.5/Interpolations/src/extrapolation/extrapolation.jl, line 54:
    begin 
        xs_1 = clamp(xs_1,lbound(etp,1),ubound(etp,1))
        xs_2 = clamp(xs_2,lbound(etp,2),ubound(etp,2))
        xs_3 = clamp(xs_3,lbound(etp,3),ubound(etp,3))
    end # /home/tim/.julia/v0.5/Interpolations/src/extrapolation/extrapolation.jl, line 55:
    etp.itp[xs_1,xs_2,xs_3]
end
```
Interpolation also involves a whole second round of `clamp`s and throws in a bunch of `floor`/`round` and arithmetic operations to boot (16 multiplies and 16 adds for linear interpolation in 3 dimensions). So one might suspect this could be fixed through a careful look at the generated code.

The first commit here is almost trivial: it adds forced-inlining to circumvent the splatting penalty. This leads to an approximately 20ns reduction in this test case. The second commit is more complicated; `size` and `indices`, when called with a dimension argument, involve a branch that looks something like this:
```julia
size(A, d) = d <= ndims(A) ? size(A)[d] : 1
```
Our generated code used these dimension-specific constructs and triggered two branches per dimension (one for `lbound` and one for `ubound`), resulting in 6 branches total for this example. Note that such branches are *not* present if you start from `sz = size(A)`, so I changed our generated code to use this style (with `indices` rather than `size`). This gave another approximate 20ns boost, so that the result with this PR is
```julia
julia> @benchmark $etp[2.2,2.2,2.2] seconds=1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     26.879 ns (0.00% GC)
  median time:      27.188 ns (0.00% GC)
  mean time:        27.413 ns (0.00% GC)
  maximum time:     46.544 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995
```
which is a much more reasonable overhead compared to interpolation.
