### PR TITLE
Use inference to decide the element type

### DIFF
--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -25,7 +25,7 @@ function BSplineInterpolation{N,Tel,TWeights<:Real,IT<:DimSpec{BSpline},GT<:DimS
     for _ in 2:N
         c *= c
     end
-    T = typeof(c * zero(Tel))
+    T = Core.Inference.return_type(*, Tuple{typeof(c), Tel})
 
     BSplineInterpolation{T,N,typeof(A),IT,GT,pad}(A)
 end

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -28,7 +28,7 @@ function GriddedInterpolation{N,TCoefs,TWeights<:Real,IT<:DimSpec{Gridded},pad}(
     for _ in 2:N
         c *= c
     end
-    T = typeof(c * zero(TCoefs))
+    T = Core.Inference.return_type(*, Tuple{typeof(c), TCoefs})
 
     GriddedInterpolation{T,N,TCoefs,IT,typeof(knts),pad}(knts, A)
 end


### PR DESCRIPTION
Fixes failures when you can't construct an instance from the type. RigidBodyTreeInspector was an example package (ref https://github.com/JuliaLang/METADATA.jl/pull/9481#issuecomment-303764913).