### PR TITLE
Bump minimum Julia version to fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 sudo: false
 julia:
-    - 0.5
     - 0.6
     - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 
 ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5


### PR DESCRIPTION
This will allow femtocleaner to do its magic.