### PR TITLE
Fix gradients for ScaledInterpolation with NoInterp

### DIFF
--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -98,8 +98,12 @@ gradient(sitp::ScaledInterpolation{T,N,ITPT,IT,GT}, xs...) where {T,N,ITPT,IT<:D
     quote
         length(g) == $(count_interp_dims(IT, N)) || throw(ArgumentError(string("The length of the provided gradient vector (", length(g), ") did not match the number of interpolating dimensions (", $(count_interp_dims(IT, N)), ")")))
         gradient!(g, sitp.itp, $(interp_indices...))
-        for i in eachindex(g)
-            g[i] = rescale_gradient(sitp.ranges[i], g[i])
+        cntr = 0
+        for i = 1:N
+                if $(interp_dimens)[i]
+                    cntr += 1
+                    g[cntr] = rescale_gradient(sitp.ranges[i], g[cntr])
+                end
         end
         g
     end

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -21,5 +21,18 @@ end
 
 @test length(gradient(sitp, pi/3, 2)) == 1
 
+# check for case where initial/middle indices are NoInterp but later ones are <:BSpline
+srand(1234)
+z0 = rand(10,10)
+za = copy(z0)
+zb = copy(z0')
+
+itpa = interpolate(za, (BSpline(Linear()), NoInterp()), OnGrid())
+itpb = interpolate(zb, (NoInterp(), BSpline(Linear())), OnGrid())
+
+rng = linspace(1.0, 19.0, 10)
+sitpa = scale(itpa, rng, 1:10)
+sitpb = scale(itpb, 1:10, rng)
+@test gradient(sitpa, 3.0, 3) ==  gradient(sitpb, 3, 3.0)
 
 end


### PR DESCRIPTION
when some dimensions had `NoInterp`(olation) and were not at the very end,
they were re-scaled with the incorrect range. This PR provides a fix & test.