### PR TITLE
Don't use generated function for FilledExtrapolation

### DIFF
--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -29,7 +29,7 @@ etpf = @inferred(extrapolate(itpg, NaN))
 
 @test etpf[2.5,1] == etpf[2.5]   # for show method
 @test_throws BoundsError etpf[2.5,2]
-@test_throws ErrorException etpf[2.5,2,1]  # this will probably become a BoundsError someday
+@test_throws BoundsError etpf[2.5,2,1]
 
 x =  @inferred(getindex(etpf, dual(-2.5,1)))
 @test isa(x, Dual)

--- a/test/extrapolation/type-stability.jl
+++ b/test/extrapolation/type-stability.jl
@@ -50,4 +50,13 @@ for (etp2,E) in map(E -> (extrapolate(itp2, E()), E), schemes),
     @inferred(getindex(etp2, x, y))
 end
 
+A = [1 2; 3 4]
+Af = Float64.(A)
+for B in (A, Af)
+    itpg = interpolate(B, BSpline(Linear()), OnGrid())
+    etp = extrapolate(itpg, NaN)
+    @test typeof(@inferred(getindex(etp, dual(1.5,1), dual(1.5,1)))) ==
+          typeof(@inferred(getindex(etp, dual(6.5,1), dual(3.5,1))))
+end
+
 end


### PR DESCRIPTION
I succeeded in triggering a [lurking Heisenbug](https://github.com/JuliaMath/Interpolations.jl/blob/0c72079474e9a47356b38b2371a396847712d242/src/b-splines/indexing.jl#L85-L87) despite the `@noinline`, though unfortunately I couldn't come up with a simple test case that reproduced it.

Getting rid of the `@generated` function seems to make it go away, and I've checked that we get the same performance, so at least I don't think this is a step backwards. It also improves the type of the error message in cases of trailing out-of-bounds indices.

Presumably some day we should just get rid of all the generated functions here in favor of lispy-tuple programming, but that's a bigger job for another day.
