### PR TITLE
use json instead of jld2 param storage for benchmarks

### DIFF
--- a/perf/benchmarks.jl
+++ b/perf/benchmarks.jl
@@ -96,12 +96,12 @@ for A in (collect(Float64, 1:3),
     end
 end
 
-paramspath = joinpath(dirname(@__FILE__), "params.jld")
+paramspath = joinpath(dirname(@__FILE__), "params.json")
 
 if isfile(paramspath)
-    loadparams!(suite, BenchmarkTools.load(paramspath, "suite"), :evals);
+    loadparams!(suite, BenchmarkTools.load(paramspath)[1], :evals);
 else
     info("Tuning suite (this may take a while)")
     tune!(suite)
-    BenchmarkTools.save(paramspath, "suite", params(suite));
+    BenchmarkTools.save(paramspath, params(suite));
 end


### PR DESCRIPTION
BenchmarkTools 0.2+ uses JSON rather than JLD2 for storing its suite parameters: https://github.com/JuliaCI/BenchmarkTools.jl/blob/30d9aaa0c674815aae5ff5fba6360fb6809869dd/doc/manual.md#caching-parameters