### PR TITLE
remove call to Core.Inference to try to fix v0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
 AxisAlgorithms
-Compat 0.19.0
+Compat 0.49
 DualNumbers

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -35,6 +35,7 @@ export
     # scaling/scaling.jl
 
 using Compat
+using Compat.LinearAlgebra
 using WoodburyMatrices, Ratios, AxisAlgorithms
 
 import Base: convert, size, indices, getindex, gradient, promote_rule,

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -25,8 +25,11 @@ function BSplineInterpolation(::Type{TWeights}, A::AbstractArray{Tel,N}, ::IT, :
     for _ in 2:N
         c *= c
     end
-    T = Base.promote_op(*, typeof(c), Tel)
-
+    if isempty(A)
+        T = Base.promote_op(*, typeof(c), Tel)
+    else
+        T = typeof(c*first(A))
+    end
     BSplineInterpolation{T,N,typeof(A),IT,GT,pad}(A)
 end
 

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -25,11 +25,7 @@ function BSplineInterpolation(::Type{TWeights}, A::AbstractArray{Tel,N}, ::IT, :
     for _ in 2:N
         c *= c
     end
-    if isempty(A)
-        T = Base.promote_op(*, typeof(c), Tel)
-    else
-        T = typeof(c*first(A))
-    end
+    T = typeof(c*first(A))
     BSplineInterpolation{T,N,typeof(A),IT,GT,pad}(A)
 end
 

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -25,7 +25,7 @@ function BSplineInterpolation(::Type{TWeights}, A::AbstractArray{Tel,N}, ::IT, :
     for _ in 2:N
         c *= c
     end
-    T = Core.Inference.return_type(*, Tuple{typeof(c), Tel})
+    T = Base.promote_op(*, typeof(c), Tel)
 
     BSplineInterpolation{T,N,typeof(A),IT,GT,pad}(A)
 end

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -25,7 +25,11 @@ function BSplineInterpolation(::Type{TWeights}, A::AbstractArray{Tel,N}, ::IT, :
     for _ in 2:N
         c *= c
     end
-    T = typeof(c*first(A))
+    if isempty(A)
+        T = Base.promote_op(*, typeof(c), eltype(A))
+    else
+        T = typeof(c * first(A))
+    end
     BSplineInterpolation{T,N,typeof(A),IT,GT,pad}(A)
 end
 

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -28,11 +28,7 @@ function GriddedInterpolation(::Type{TWeights}, knots::NTuple{N,GridIndex}, A::A
     for _ in 2:N
         c *= c
     end
-    if isempty(A)
-        T = Base.promote_op(*, typeof(c), Tel)
-    else
-        T = typeof(c*first(A))
-    end
+    T = typeof(c*first(A))
     GriddedInterpolation{T,N,TCoefs,IT,typeof(knts),pad}(knts, A)
 end
 

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -28,7 +28,11 @@ function GriddedInterpolation(::Type{TWeights}, knots::NTuple{N,GridIndex}, A::A
     for _ in 2:N
         c *= c
     end
-    T = typeof(c*first(A))
+    if isempty(A)
+        T = Base.promote_op(*, typeof(c), eltype(A))
+    else
+        T = typeof(c * first(A))
+    end
     GriddedInterpolation{T,N,TCoefs,IT,typeof(knts),pad}(knts, A)
 end
 

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -28,7 +28,7 @@ function GriddedInterpolation(::Type{TWeights}, knots::NTuple{N,GridIndex}, A::A
     for _ in 2:N
         c *= c
     end
-    T = Core.Inference.return_type(*, Tuple{typeof(c), TCoefs})
+    T = Base.promote_op(*, typeof(c), TCoefs)
 
     GriddedInterpolation{T,N,TCoefs,IT,typeof(knts),pad}(knts, A)
 end

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -28,8 +28,11 @@ function GriddedInterpolation(::Type{TWeights}, knots::NTuple{N,GridIndex}, A::A
     for _ in 2:N
         c *= c
     end
-    T = Base.promote_op(*, typeof(c), TCoefs)
-
+    if isempty(A)
+        T = Base.promote_op(*, typeof(c), Tel)
+    else
+        T = typeof(c*first(A))
+    end
     GriddedInterpolation{T,N,TCoefs,IT,typeof(knts),pad}(knts, A)
 end
 


### PR DESCRIPTION
As far as I know, directly calling `Core.Inference` is not generally recommended. `Base.promote_op` should do the same thing in this case and also works correctly on Julia v0.7. 