### PR TITLE
move promote_type call inside the generated function body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ julia:
 matrix:
     allow_failures:
         - julia: nightly
+after_success:
+  # push coverage results to Coveralls
+  - julia -e 'cd(Pkg.dir("WebIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  # push coverage results to Codecov
+- julia -e 'cd(Pkg.dir("WebIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("WebIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-- julia -e 'cd(Pkg.dir("WebIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'cd(Pkg.dir("WebIO")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -160,9 +160,11 @@ end
 
 @generated function hessian(itp::AbstractInterpolation{T,N}, xs...) where {T,N}
     n = count_interp_dims(itp,N)
-    TH = promote_type(T, [x <: AbstractArray ? eltype(x) : x for x in xs]...)
     xargs = [:(xs[$d]) for d in 1:length(xs)]
-    :(hessian!(Array{TH, 2}($n,$n), itp, $(xargs...)))
+    quote
+        TH = $(Expr(:call, :promote_type, T, [x <: AbstractArray ? eltype(x) : x for x in xs]...))
+        hessian!(Array{TH, 2}($n,$n), itp, $(xargs...))
+    end
 end
 
 hessian1(itp::AbstractInterpolation{T,1}, x) where {T} = hessian(itp, x)[1,1]

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -108,9 +108,11 @@ end
 for R in [:Real, :Any]
     @eval @generated function gradient(itp::AbstractInterpolation{T,N}, xs::$R...) where {T,N}
         n = count_interp_dims(itp, N)
-        Tg = promote_type(T, [x <: AbstractArray ? eltype(x) : x for x in xs]...)
         xargs = [:(xs[$d]) for d in 1:length(xs)]
-        :(gradient!(Array{$Tg, 1}($n), itp, $(xargs...)))
+        quote
+            Tg = $(Expr(:call, :promote_type, T, [x <: AbstractArray ? eltype(x) : x for x in xs]...))
+            gradient!(Array{Tg, 1}($n), itp, $(xargs...))
+        end
     end
 end
 


### PR DESCRIPTION
Fixes #207 (at least for the particular case i showed there). 

I also changed the equivalent code in `hessian()`, although i think that code may have been broken already (`Array{TH` should have been `Array{$TH`). I'll see what the test coverage says. 

Anyway, please let me know if you think this is the right thing to do. If so, I should be able to construct a test to make sure #207 is really fixed. 