### PR TITLE
Fixes for julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: julia
 sudo: false
 julia:
     - 0.6
+    - 0.7
     - nightly
 matrix:
     allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,5 @@ ShowItLikeYouBuildIt
 WoodburyMatrices 0.1.5
 Ratios
 AxisAlgorithms
-Compat 0.49
+OffsetArrays
+Compat 0.59

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -38,18 +38,19 @@ export
     # scaling/scaling.jl
 
 using Compat
-using Compat.LinearAlgebra
-using WoodburyMatrices, Ratios, AxisAlgorithms
+using Compat.LinearAlgebra, Compat.SparseArrays
+using WoodburyMatrices, Ratios, AxisAlgorithms, OffsetArrays
 
-import Base: convert, size, indices, getindex, gradient, promote_rule,
+import Base: convert, size, getindex, promote_rule,
              ndims, eltype, checkbounds
 
-# Julia v0.5 compatibility
-if isdefined(:scaling) import Base.scaling end
-if isdefined(:scale) import Base.scale end
-if !isdefined(Base, :oneunit)
-    const oneunit = one
+@static if VERSION < v"0.7.0-DEV.3449"
+    import Base: gradient
+else
+    import LinearAlgebra: gradient
 end
+
+import Compat: axes
 
 abstract type Flag end
 abstract type InterpolationType <: Flag end

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -51,3 +51,15 @@ function index_gen(::Type{BSpline{Constant}}, ::Type{IT}, N::Integer, offsets...
         return :(itp.coefs[$(indices...)])
     end
 end
+
+# FIXME: needed due to a Julia inference bug (in julia 0.7)
+function index_gen(::Type{BSpline{Constant}}, ::Type{BSpline{Constant}}, N::Integer, offsets...)
+    if (length(offsets) < N)
+        d = length(offsets)+1
+        sym = Symbol("c_", d)
+        return :($sym * $(index_gen(BSpline{Constant}, BSpline{Constant}, N, offsets..., 0)))
+    else
+        indices = [offsetsym(offsets[d], d) for d = 1:N]
+        return :(itp.coefs[$(indices...)])
+    end
+end

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -31,7 +31,7 @@ function getindex_impl(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}) wh
     quote
         $meta
         @nexprs $N d->(x_d = xs[d])
-        inds_itp = indices(itp)
+        inds_itp = axes(itp)
 
         # Calculate the indices of all coefficients that will be used
         # and define fx = x - xi in each dimension
@@ -60,7 +60,7 @@ function gradient_impl(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}) wh
     # For each component of the gradient, alternately calculate
     # coefficients and set component
     n = count_interp_dims(IT, N)
-    exs = Array{Expr, 1}(2n)
+    exs = Array{Expr, 1}(undef, 2n)
     cntr = 0
     for d = 1:N
         if count_interp_dims(iextract(IT, d), 1) > 0
@@ -74,7 +74,7 @@ function gradient_impl(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}) wh
         $meta
         length(g) == $n || throw(ArgumentError(string("The length of the provided gradient vector (", length(g), ") did not match the number of interpolating dimensions (", n, ")")))
         @nexprs $N d->(x_d = xs[d])
-        inds_itp = indices(itp)
+        inds_itp = axes(itp)
 
         # Calculate the indices of all coefficients that will be used
         # and define fx = x - xi in each dimension
@@ -115,7 +115,7 @@ for R in [:Real, :Any]
         xargs = [:(xs[$d]) for d in 1:length(xs)]
         quote
             Tg = $(Expr(:call, :promote_type, T, [x <: AbstractArray ? eltype(x) : x for x in xs]...))
-            gradient!(Array{Tg, 1}($n), itp, $(xargs...))
+            gradient!(Array{Tg, 1}(undef, $n), itp, $(xargs...))
         end
     end
 end
@@ -142,7 +142,7 @@ function hessian_impl(itp::Type{BSplineInterpolation{T,N,TCoefs,IT,GT,Pad}}) whe
         $meta
         size(H) == ($n,$n) || throw(ArgumentError(string("The size of the provided Hessian matrix wasn't a square matrix of size ", size(H))))
         @nexprs $N d->(x_d = xs[d])
-        inds_itp = indices(itp)
+        inds_itp = axes(itp)
 
         $(define_indices(IT, N, Pad))
 
@@ -167,7 +167,7 @@ end
     xargs = [:(xs[$d]) for d in 1:length(xs)]
     quote
         TH = $(Expr(:call, :promote_type, T, [x <: AbstractArray ? eltype(x) : x for x in xs]...))
-        hessian!(Array{TH, 2}($n,$n), itp, $(xargs...))
+        hessian!(Array{TH, 2}(undef, $n,$n), itp, $(xargs...))
     end
 end
 

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -101,3 +101,16 @@ function index_gen(::Type{BSpline{Linear}}, ::Type{IT}, N::Integer, offsets...) 
         return :(itp.coefs[$(indices...)])
     end
 end
+
+# FIXME: needed due to a Julia inference bug (in julia 0.7)
+function index_gen(::Type{BSpline{Linear}}, ::Type{BSpline{Linear}}, N::Integer, offsets...)
+    if length(offsets) < N
+        d = length(offsets)+1
+        sym = Symbol("c_", d)
+        symp = Symbol("cp_", d)
+        return :($sym * $(index_gen(BSpline{Linear}, BSpline{Linear}, N, offsets..., 0)) + $symp * $(index_gen(BSpline{Linear}, BSpline{Linear}, N, offsets..., 1)))
+    else
+        indices = [offsetsym(offsets[d], d) for d = 1:N]
+        return :(itp.coefs[$(indices...)])
+    end
+end

--- a/src/b-splines/prefiltering.jl
+++ b/src/b-splines/prefiltering.jl
@@ -7,30 +7,45 @@ padding(::Type{IT}) where {IT<:BSpline} = Val{0}()
 end
 
 @noinline function padded_index(indsA::NTuple{N,AbstractUnitRange{Int}}, ::Val{pad}) where {N,pad}
-    indspad = ntuple(i->indices_addpad(indsA[i], padextract(pad,i)), Val{N})
-    indscp = ntuple(i->indices_interior(indspad[i], padextract(pad,i)), Val{N})
+    @static if VERSION < v"0.7.0-DEV.843"
+        indspad = ntuple(i->indices_addpad(indsA[i], padextract(pad,i)), Val{N})
+        indscp = ntuple(i->indices_interior(indspad[i], padextract(pad,i)), Val{N})
+    else
+        indspad = ntuple(i->indices_addpad(indsA[i], padextract(pad,i)), Val(N))
+        indscp = ntuple(i->indices_interior(indspad[i], padextract(pad,i)), Val(N))
+    end
     indscp, indspad
+end
+
+padded_similar(::Type{TC}, inds::Tuple{Vararg{Base.OneTo{Int}}}) where TC = Array{TC}(undef, length.(inds))
+padded_similar(::Type{TC}, inds) where TC = OffsetArray{TC}(undef, inds)
+
+# despite Compat, julia doesn't support 0.6 copy! with CartesianIndices argument
+@static if isdefined(Base, :CartesianIndices)
+    ct!(coefs, indscp, A, indsA) = copyto!(coefs, CartesianIndices(indscp), A, CartesianIndices(indsA))
+else
+    ct!(coefs, indscp, A, indsA) = copyto!(coefs, CartesianRange(indscp), A, CartesianRange(indsA))
 end
 
 copy_with_padding(A, ::Type{IT}) where {IT} = copy_with_padding(eltype(A), A, IT)
 function copy_with_padding(::Type{TC}, A, ::Type{IT}) where {TC,IT<:DimSpec{InterpolationType}}
     Pad = padding(IT)
-    indsA = indices(A)
+    indsA = axes(A)
     indscp, indspad = padded_index(indsA, Pad)
-    coefs = similar(dims->Array{TC}(dims), indspad)
+    coefs = padded_similar(TC, indspad)
     if indspad == indsA
-        coefs = copy!(coefs, A)
+        coefs = copyto!(coefs, A)
     else
         fill!(coefs, zero(TC))
-        copy!(coefs, CartesianRange(indscp), A, CartesianRange(indsA))
+        ct!(coefs, indscp, A, indsA)
     end
     coefs, Pad
 end
 
 prefilter!(::Type{TWeights}, A, ::Type{IT}, ::Type{GT}) where {TWeights, IT<:BSpline, GT<:GridType} = A
 function prefilter(::Type{TWeights}, ::Type{TC}, A, ::Type{IT}, ::Type{GT}) where {TWeights, TC, IT<:BSpline, GT<:GridType}
-    coefs = similar(dims->Array{TC}(dims), indices(A))
-    prefilter!(TWeights, copy!(coefs, A), IT, GT), Val{0}()
+    coefs = padded_similar(TC, axes(A))
+    prefilter!(TWeights, copyto!(coefs, A), IT, GT), Val{0}()
 end
 
 function prefilter(
@@ -51,7 +66,7 @@ function prefilter!(
     ::Type{TWeights}, ret::TCoefs, ::Type{BSpline{IT}}, ::Type{GT}
     ) where {TWeights,TCoefs<:AbstractArray,IT<:Union{Quadratic,Cubic},GT<:GridType}
     local buf, shape, retrs
-    sz = map(length, indices(ret))
+    sz = map(length, axes(ret))
     first = true
     for dim in 1:ndims(ret)
         M, b = prefiltering_system(TWeights, eltype(TCoefs), sz[dim], IT, GT)

--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -142,6 +142,18 @@ function index_gen(::Type{BSpline{Q}}, ::Type{IT}, N::Integer, offsets...) where
     end
 end
 
+function index_gen(::Type{BS}, ::Type{BS}, N::Integer, offsets...) where {BS<:BSpline{<:Quadratic}}
+    if length(offsets) < N
+        d = length(offsets)+1
+        symm, sym, symp =  Symbol("cm_",d), Symbol("c_",d), Symbol("cp_",d)
+        return :($symm * $(index_gen(BS, BS, N, offsets...,-1)) + $sym * $(index_gen(BS, BS, N, offsets..., 0)) +
+                 $symp * $(index_gen(BS, BS, N, offsets..., 1)))
+    else
+        indices = [offsetsym(offsets[d], d) for d = 1:N]
+        return :(itp.coefs[$(indices...)])
+    end
+end
+
 padding(::Type{BSpline{Quadratic{BC}}}) where {BC<:Flag} = Val{1}()
 padding(::Type{BSpline{Quadratic{Periodic}}}) = Val{0}()
 
@@ -162,13 +174,13 @@ function prefiltering_system(::Type{T}, ::Type{TC}, n::Int, ::Type{Quadratic{BC}
     dl,d,du = inner_system_diags(T,n,Quadratic{BC})
     d[1] = d[end] = -1
     du[1] = dl[end] = 1
-    lufact!(Tridiagonal(dl, d, du), Val{false}), zeros(TC, n)
+    lut!(dl, d, du), zeros(TC, n)
 end
 
 function prefiltering_system(::Type{T}, ::Type{TC}, n::Int, ::Type{Quadratic{InPlace}}, ::Type{OnCell}) where {T,TC}
     dl,d,du = inner_system_diags(T,n,Quadratic{InPlace})
     d[1] = d[end] = convert(T, SimpleRatio(7,8))
-    lufact!(Tridiagonal(dl, d, du), Val{false}), zeros(TC, n)
+    lut!(dl, d, du), zeros(TC, n)
 end
 
 # InPlaceQ continues the quadratic at 2 all the way down to 1 (rather than 1.5)
@@ -183,7 +195,7 @@ function prefiltering_system(::Type{T}, ::Type{TC}, n::Int, ::Type{Quadratic{InP
     valspec[1,1] = valspec[2,2] = SimpleRatio(1,8)
     rowspec[1,1] = rowspec[n,2] = 1
     colspec[1,3] = colspec[2,n-2] = 1
-    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), rowspec, valspec, colspec), zeros(TC, n)
+    Woodbury(lut!(dl, d, du), rowspec, valspec, colspec), zeros(TC, n)
 end
 
 """
@@ -202,7 +214,7 @@ function prefiltering_system(::Type{T}, ::Type{TC}, n::Int, ::Type{Quadratic{BC}
                                   (n, n-2, oneunit(T))
                                  )
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), specs...), zeros(TC, n)
+    Woodbury(lut!(dl, d, du), specs...), zeros(TC, n)
 end
 
 """
@@ -222,7 +234,7 @@ function prefiltering_system(::Type{T}, ::Type{TC}, n::Int, ::Type{Quadratic{Lin
                                   (n, n-2, oneunit(T)),
                                   )
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), specs...), zeros(TC, n)
+    Woodbury(lut!(dl, d, du), specs...), zeros(TC, n)
 end
 
 """
@@ -243,7 +255,7 @@ function prefiltering_system(::Type{T}, ::Type{TC}, n::Int, ::Type{Quadratic{Fre
                                     (n, n-2, 3),
                                     (n, n-3, -1))
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), specs...), zeros(TC, n)
+    Woodbury(lut!(dl, d, du), specs...), zeros(TC, n)
 end
 
 """
@@ -262,5 +274,5 @@ function prefiltering_system(::Type{T}, ::Type{TC}, n::Int, ::Type{Quadratic{Per
                                   (n, 1, dl[end])
                                   )
 
-    Woodbury(lufact!(Tridiagonal(dl, d, du), Val{false}), specs...), zeros(TC, n)
+    Woodbury(lut!(dl, d, du), specs...), zeros(TC, n)
 end

--- a/src/convenience-constructors.jl
+++ b/src/convenience-constructors.jl
@@ -1,10 +1,10 @@
 # convenience copnstructors for linear / cubic spline interpolations
 # 1D version
-LinearInterpolation(range::T, vs; extrapolation_bc = Interpolations.Throw()) where {T <: Range} = extrapolate(scale(interpolate(vs, BSpline(Linear()), OnGrid()), range), extrapolation_bc)
+LinearInterpolation(range::T, vs; extrapolation_bc = Interpolations.Throw()) where {T <: AbstractRange} = extrapolate(scale(interpolate(vs, BSpline(Linear()), OnGrid()), range), extrapolation_bc)
 LinearInterpolation(range::T, vs; extrapolation_bc = Interpolations.Throw()) where {T <: AbstractArray} = extrapolate(interpolate((range, ), vs, Gridded(Linear())), extrapolation_bc)
-CubicSplineInterpolation(range::T, vs; bc = Interpolations.Line(), extrapolation_bc = Interpolations.Throw()) where {T <: Range} = extrapolate(scale(interpolate(vs, BSpline(Cubic(bc)), OnGrid()), range), extrapolation_bc)
+CubicSplineInterpolation(range::T, vs; bc = Interpolations.Line(), extrapolation_bc = Interpolations.Throw()) where {T <: AbstractRange} = extrapolate(scale(interpolate(vs, BSpline(Cubic(bc)), OnGrid()), range), extrapolation_bc)
 
 # multivariate versions
-LinearInterpolation(ranges::NTuple{N,T}, vs; extrapolation_bc = Interpolations.Throw()) where {N,T <: Range} = extrapolate(scale(interpolate(vs, BSpline(Linear()), OnGrid()), ranges...), extrapolation_bc)
+LinearInterpolation(ranges::NTuple{N,T}, vs; extrapolation_bc = Interpolations.Throw()) where {N,T <: AbstractRange} = extrapolate(scale(interpolate(vs, BSpline(Linear()), OnGrid()), ranges...), extrapolation_bc)
 LinearInterpolation(ranges::NTuple{N,T}, vs; extrapolation_bc = Interpolations.Throw()) where {N,T <: AbstractArray} = extrapolate(interpolate(ranges, vs, Gridded(Linear())), extrapolation_bc)
-CubicSplineInterpolation(ranges::NTuple{N,T}, vs; bc = Interpolations.Line(), extrapolation_bc = Interpolations.Throw()) where {N,T <: Range} = extrapolate(scale(interpolate(vs, BSpline(Cubic(bc)), OnGrid()), ranges...), extrapolation_bc)
+CubicSplineInterpolation(ranges::NTuple{N,T}, vs; bc = Interpolations.Line(), extrapolation_bc = Interpolations.Throw()) where {N,T <: AbstractRange} = extrapolate(scale(interpolate(vs, BSpline(Cubic(bc)), OnGrid()), ranges...), extrapolation_bc)

--- a/src/extrapolation/extrap_prep.jl
+++ b/src/extrapolation/extrap_prep.jl
@@ -39,7 +39,7 @@ value cases need to be implemented for each scheme.
 """ extrap_prep
 
 extrap_prep(::Type{T}, n::Val{1}) where {T} = quote
-    inds_etp = indices(etp)
+    inds_etp = axes(etp)
     $(extrap_prep(T, n, Val{1}()))
 end
 extrap_prep(::Type{Tuple{T}}, n::Val{1}) where {T} = extrap_prep(T, n)
@@ -47,7 +47,7 @@ extrap_prep(::Type{Tuple{T,T}}, n::Val{1}) where {T} = extrap_prep(T, n)
 extrap_prep(::Type{Tuple{Tuple{T,T}}}, n::Val{1}) where {T} = extrap_prep(T, n)
 function extrap_prep(::Type{Tuple{S,T}}, n::Val{1}) where {S,T}
     quote
-        inds_etp = indices(etp)
+        inds_etp = axes(etp)
         $(extrap_prep(S, n, Val{1}(), Val{:lo}()))
         $(extrap_prep(T, n, Val{1}(), Val{:hi}()))
     end
@@ -58,7 +58,7 @@ extrap_prep(::Type{Tuple{Tuple{S,T}}}, n::Val{1}) where {S,T} = extrap_prep(Tupl
 extrap_prep(::Type{T}, ::Val{1}) where {T<:Tuple} = :(throw(ArgumentError("The 1-dimensional extrap configuration $T is not supported")))
 
 function extrap_prep(::Type{T}, n::Val{N}) where {T,N}
-    exprs = [:(inds_etp = indices(etp))]
+    exprs = [:(inds_etp = axes(etp))]
     for d in 1:N
         push!(exprs, extrap_prep(T, n, Val{d}()))
     end
@@ -66,7 +66,7 @@ function extrap_prep(::Type{T}, n::Val{N}) where {T,N}
 end
 function extrap_prep(::Type{T}, n::Val{N}) where {N,T<:Tuple}
     length(T.parameters) == N || return :(throw(ArgumentError("The $N-dimensional extrap configuration $T is not supported - must be a tuple of length $N (was length $(length(T.parameters)))")))
-    exprs = [:(inds_etp = indices(etp))]
+    exprs = [:(inds_etp = axes(etp))]
     for d in 1:N
         Tdim = T.parameters[d]
         if Tdim <: Tuple

--- a/src/extrapolation/extrap_prep_gradient.jl
+++ b/src/extrapolation/extrap_prep_gradient.jl
@@ -1,7 +1,7 @@
 # See ?extrap_prep for documentation for all these methods
 
 extrap_prep(g::Val{:gradient}, ::Type{T}, n::Val{1}) where {T} = quote
-    inds_etp = indices(etp)
+    inds_etp = axes(etp)
     $(extrap_prep(g, T, n, Val{1}()))
 end
 extrap_prep(g::Val{:gradient}, ::Type{Tuple{T}}, n::Val{1}) where {T} = extrap_prep(g, T, n)
@@ -9,7 +9,7 @@ extrap_prep(g::Val{:gradient}, ::Type{Tuple{T,T}}, n::Val{1}) where {T} = extrap
 extrap_prep(g::Val{:gradient}, ::Type{Tuple{Tuple{T,T}}}, n::Val{1}) where {T} = extrap_prep(g, T, n)
 function extrap_prep(g::Val{:gradient}, ::Type{Tuple{S,T}}, ::Val{1}) where {S,T}
     quote
-        inds_etp = indices(etp)
+        inds_etp = axes(etp)
         $(extrap_prep(g, S, n, Val{1}(), Val{:lo}()))
         $(extrap_prep(g, T, n, Val{1}(), Val{:hi}()))
     end
@@ -20,12 +20,12 @@ extrap_prep(::Val{:gradient}, ::Type{T}, ::Val{1}) where {T<:Tuple} = :(throw(Ar
 
 
 function extrap_prep(g::Val{:gradient}, ::Type{T}, n::Val{N}) where {T,N}
-    Expr(:block, :(inds_etp = indices(etp)), [extrap_prep(g, T, n, Val{d}()) for d in 1:N]...)
+    Expr(:block, :(inds_etp = axes(etp)), [extrap_prep(g, T, n, Val{d}()) for d in 1:N]...)
 end
 
 function extrap_prep(g::Val{:gradient}, ::Type{T}, n::Val{N}) where {T<:Tuple,N}
     length(T.parameters) == N || return :(throw(ArgumentError("The $N-dimensional extrap configuration $T is not supported")))
-    exprs = [:(inds_etp = indices(etp))]
+    exprs = [:(inds_etp = axes(etp))]
     for d in 1:N
         Tdim = T.parameters[d]
         if Tdim <: Tuple

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -2,8 +2,6 @@ mutable struct Extrapolation{T,N,ITPT,IT,GT,ET} <: AbstractExtrapolation{T,N,ITP
     itp::ITPT
 end
 
-@deprecate Extrapolation{T,ITPT,IT,GT,ET}(::Type{T}, N, itp::ITPT, ::Type{IT}, ::Type{GT}, et::ET) Extrapolation{T,N,ITPT,IT,GT,ET}(itp)
-
 Base.parent(A::Extrapolation) = A.itp
 
 # DimSpec{Flag} is not enough for extrapolation dispatch, since we allow nested tuples
@@ -91,7 +89,7 @@ ubound(etp::Extrapolation, d) = ubound(etp.itp, d)
 lbound(etp::Extrapolation, d, inds) = lbound(etp.itp, d, inds)
 ubound(etp::Extrapolation, d, inds) = ubound(etp.itp, d, inds)
 size(etp::Extrapolation, d) = size(etp.itp, d)
-@inline indices(etp::AbstractExtrapolation) = indices(etp.itp)
-indices(etp::AbstractExtrapolation, d) = indices(etp.itp, d)
+@inline axes(etp::AbstractExtrapolation) = axes(etp.itp)
+axes(etp::AbstractExtrapolation, d) = axes(etp.itp, d)
 
 include("filled.jl")

--- a/src/gridded/constant.jl
+++ b/src/gridded/constant.jl
@@ -30,3 +30,14 @@ function index_gen(::Type{Gridded{Constant}}, ::Type{IT}, N::Integer, offsets...
         return :(itp.coefs[$(indices...)])
     end
 end
+
+function index_gen(::Type{Gridded{Constant}}, ::Type{Gridded{Constant}}, N::Integer, offsets...)
+    if (length(offsets) < N)
+        d = length(offsets)+1
+        sym = Symbol("c_", d)
+        return :($sym * $(index_gen(Gridded{Constant}, Gridded{Constant}, N, offsets..., 0)))
+    else
+        indices = [offsetsym(offsets[d], d) for d = 1:N]
+        return :(itp.coefs[$(indices...)])
+    end
+end

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -14,8 +14,8 @@ struct GriddedInterpolation{T,N,TCoefs,IT<:DimSpec{Gridded},K<:Tuple{Vararg{Vect
     coefs::Array{TCoefs,N}
 end
 function GriddedInterpolation(::Type{TWeights}, knots::NTuple{N,GridIndex}, A::AbstractArray{TCoefs,N}, ::IT, ::Val{pad}) where {N,TCoefs,TWeights<:Real,IT<:DimSpec{Gridded},pad}
-    isleaftype(IT) || error("The b-spline type must be a leaf type (was $IT)")
-    isleaftype(TCoefs) || warn("For performance reasons, consider using an array of a concrete type (eltype(A) == $(eltype(A)))")
+    isconcretetype(IT) || error("The b-spline type must be a leaf type (was $IT)")
+    isconcretetype(TCoefs) || warn("For performance reasons, consider using an array of a concrete type (eltype(A) == $(eltype(A)))")
 
     knts = mapcollect(knots...)
     for (d,k) in enumerate(knts)

--- a/src/gridded/indexing.jl
+++ b/src/gridded/indexing.jl
@@ -67,7 +67,7 @@ end
             @nexprs $N d->begin
                 xv_d = xv[d]
                 k_d = itp.knots[d]
-                ixv_d = Array{Int}( length(xv_d))  # ixv_d[i] is the smallest value such that k_d[ixv_d[i]] <= x_d[i]
+                ixv_d = Array{Int}(undef, length(xv_d))  # ixv_d[i] is the smallest value such that k_d[ixv_d[i]] <= x_d[i]
                 # If x_d is sorted and has quite a few entries, it's better to match
                 # entries of x_d and k_d by iterating through them both in unison.
                 l_d = length(k_d)   # FIXME: check l_d == 1 someday, see FIXME above
@@ -98,7 +98,7 @@ end
 end
 
 function getindex(itp::GriddedInterpolation{T,N,TCoefs,IT,K,P}, x...) where {T,N,TCoefs,IT<:DimSpec{Gridded},K,P}
-    dest = Array{T}( map(length, x))::Array{T,N}
+    dest = Array{T}(undef, map(length, x))::Array{T,N}
     getindex!(dest, itp, x...)
 end
 
@@ -107,7 +107,7 @@ function gradient_impl(itp::Type{GriddedInterpolation{T,N,TCoefs,IT,K,P}}) where
     # For each component of the gradient, alternately calculate
     # coefficients and set component
     n = count_interp_dims(IT, N)
-    exs = Array{Expr}( 2n)
+    exs = Array{Expr}(undef, 2n)
     cntr = 0
     for d = 1:N
         if count_interp_dims(iextract(IT, d), 1) > 0

--- a/src/gridded/linear.jl
+++ b/src/gridded/linear.jl
@@ -41,3 +41,16 @@ function index_gen(::Type{Gridded{Linear}}, ::Type{IT}, N::Integer, offsets...) 
         return :(itp.coefs[$(indices...)])
     end
 end
+
+# FIXME: needed due to a Julia inference bug (in julia 0.7)
+function index_gen(::Type{Gridded{Linear}}, ::Type{Gridded{Linear}}, N::Integer, offsets...)
+    if length(offsets) < N
+        d = length(offsets)+1
+        sym = Symbol("c_", d)
+        symp = Symbol("cp_", d)
+        return :($sym * $(index_gen(Gridded{Linear}, Gridded{Linear}, N, offsets..., 0)) + $symp * $(index_gen(Gridded{Linear}, Gridded{Linear}, N, offsets..., 1)))
+    else
+        indices = [offsetsym(offsets[d], d) for d = 1:N]
+        return :(itp.coefs[$(indices...)])
+    end
+end

--- a/src/nointerp/nointerp.jl
+++ b/src/nointerp/nointerp.jl
@@ -22,6 +22,16 @@ function index_gen(::Type{NoInterp}, ::Type{IT}, N::Integer, offsets...) where I
     end
 end
 
+# FIXME: needed due to a Julia inference bug (in julia 0.7)
+function index_gen(::Type{NoInterp}, ::Type{NoInterp}, N::Integer, offsets...)
+    if (length(offsets) < N)
+        return :($(index_gen(NoInterp, NoInterp, N, offsets..., 0)))
+    else
+        indices = [offsetsym(offsets[d], d) for d = 1:N]
+        return :(itp.coefs[$(indices...)])
+    end
+end
+
 padding(::Type{NoInterp}) = Val{0}()
 
 # How many non-NoInterp dimensions are there?

--- a/test/b-splines/constant.jl
+++ b/test/b-splines/constant.jl
@@ -1,7 +1,7 @@
 module ConstantTests
 
 using Interpolations
-using Base.Test
+using Compat.Test
 
 # Instantiation
 N1 = 10

--- a/test/b-splines/cubic.jl
+++ b/test/b-splines/cubic.jl
@@ -1,6 +1,6 @@
 module CubicTests
 
-using Base.Test
+using Compat.Test
 using Interpolations
 
 for (constructor, copier) in ((interpolate, identity), (interpolate!, copy))
@@ -55,7 +55,8 @@ end
 
 module CubicGradientTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test, Compat.LinearAlgebra
+using Compat: range
 
 ix = 1:15
 f(x) = cos((x-1)*2pi/(length(ix)-1))
@@ -69,7 +70,7 @@ for (constructor, copier) in ((interpolate, identity), (interpolate!, copy))
 
         itp = constructor(copier(A), BSpline(Cubic(BC())), GT())
         # test that inner region is close to data
-        for x in linspace(ix[5],ix[end-4],100)
+        for x in range(ix[5], stop=ix[end-4], length=100)
             @test ≈(g(x),(gradient(itp,x))[1],atol=cbrt(cbrt(eps(g(x)))))
         end
     end

--- a/test/b-splines/function-call-syntax.jl
+++ b/test/b-splines/function-call-syntax.jl
@@ -1,6 +1,7 @@
 module ExtrapFunctionCallSyntax
 
-using Base.Test, Interpolations, DualNumbers
+using Compat.Test, Interpolations, DualNumbers
+using Compat: range
 
 # Test if b-spline interpolation by function syntax yields identical results
 f(x) = sin((x-3)*2pi/9 - 1)
@@ -11,12 +12,12 @@ schemes = (Flat,Line,Free)
 
 for T in (Cubic, Quadratic), GC in (OnGrid, OnCell)
     for etp in map(S -> @inferred(interpolate(A, BSpline(T(S())), GC())), schemes),
-        x in linspace(1,xmax,100)
+        x in range(1, stop=xmax, length=100)
         @test (getindex(etp, x)) == etp(x)
     end
 end
 
-for T in (Constant, Linear), GC in (OnGrid, OnCell), x in linspace(1,xmax,100)
+for T in (Constant, Linear), GC in (OnGrid, OnCell), x in range(1, stop=xmax, length=100)
     etp = interpolate(A, BSpline(T()), GC())
     @test (getindex(etp, x)) == etp(x)
 end

--- a/test/b-splines/linear.jl
+++ b/test/b-splines/linear.jl
@@ -1,7 +1,7 @@
 module LinearTests
 
 using Interpolations
-using Base.Test
+using Compat.Test
 
 xmax = 10
 g1(x) = sin((x-3)*2pi/(xmax-1)-1)

--- a/test/b-splines/mixed.jl
+++ b/test/b-splines/mixed.jl
@@ -1,6 +1,6 @@
 module MixedTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat, Compat.Test, Compat.SharedArrays, Compat.Random
 
 N = 10
 
@@ -31,7 +31,7 @@ end
 makesharedarray(::Type{T}, dims; kwargs...) where {T} = SharedArray{T}(dims; kwargs...)
 function copyshared(A)
     B = makesharedarray(eltype(A), size(A))
-    copy!(B, A)
+    copyto!(B, A)
 end
 
 for (constructor, copier) in ((interpolate, x->x), (interpolate!, copyshared))

--- a/test/b-splines/multivalued.jl
+++ b/test/b-splines/multivalued.jl
@@ -24,7 +24,7 @@ Base.promote_op(::typeof(*), ::Type{MyPair{T1}}, ::Type{T2}) where {T1,T2<:Numbe
 Base.promote_op(::typeof(*), ::Type{T1}, ::Type{MyPair{T2}}) where {T1<:Number,T2} = MyPair{promote_type(T1,T2)}
 
 # 1d
-A = reinterpret(MyPair{Float64}, rand(2, 10), (10,))
+A = reinterpret(MyPair{Float64}, rand(20))
 itp = interpolate(A, BSpline(Constant()), OnGrid())
 itp[3.2]
 itp = interpolate(A, BSpline(Linear()), OnGrid())
@@ -33,7 +33,7 @@ itp = interpolate(A, BSpline(Quadratic(Flat())), OnGrid())
 itp[3.2]
 
 # 2d
-A = reinterpret(MyPair{Float64}, rand(2, 10, 5), (10,5))
+A = reshape(reinterpret(MyPair{Float64}, rand(100)), (10,5))
 itp = interpolate(A, BSpline(Constant()), OnGrid())
 itp[3.2,1.8]
 itp = interpolate(A, BSpline(Linear()), OnGrid())

--- a/test/b-splines/non1.jl
+++ b/test/b-splines/non1.jl
@@ -1,15 +1,16 @@
 module Non1Tests
 
-using Interpolations, OffsetArrays, AxisAlgorithms, Base.Test
+using Interpolations, OffsetArrays, AxisAlgorithms, Compat.Test
+using Compat: axes
 
 # At present, for a particular type of non-1 array you need to specialize this function
 function AxisAlgorithms.A_ldiv_B_md!(dest::OffsetArray, F, src::OffsetArray, dim::Integer, b::AbstractVector)
-    indsdim = indices(parent(src), dim)
-    indsF = indices(F)[2]
+    indsdim = axes(parent(src), dim)
+    indsF = axes(F)[2]
     if indsF == indsdim
         return A_ldiv_B_md!(parent(dest), F, parent(src), dim, b)
     end
-    throw(DimensionMismatch("indices $(indices(parent(src))) do not match $(indices(F))"))
+    throw(DimensionMismatch("indices $(axes(parent(src))) do not match $(axes(F))"))
 end
 
 for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
@@ -23,7 +24,7 @@ for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
 
     for GT in (OnGrid, OnCell), O in (Constant, Linear)
         itp1 = @inferred(constructor(copier(A1), BSpline(O()), GT()))
-        @test @inferred(indices(itp1)) === indices(A1)
+        @test @inferred(axes(itp1)) === axes(A1)
 
         # test that we reproduce the values at on-grid points
         for x = inds
@@ -31,7 +32,7 @@ for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
         end
 
         itp2 = @inferred(constructor(copier(A2), BSpline(O()), GT()))
-        @test @inferred(indices(itp2)) === indices(A2)
+        @test @inferred(axes(itp2)) === axes(A2)
         for j = yinds, i = xinds
             @test itp2[i,j] ≈ A2[i,j]
         end
@@ -39,7 +40,7 @@ for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
 
     for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
         itp1 = @inferred(constructor(copier(A1), BSpline(Quadratic(BC())), GT()))
-        @test @inferred(indices(itp1)) === indices(A1)
+        @test @inferred(axes(itp1)) === axes(A1)
 
         # test that we reproduce the values at on-grid points
         inset = constructor == interpolate!
@@ -48,7 +49,7 @@ for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
         end
 
         itp2 = @inferred(constructor(copier(A2), BSpline(Quadratic(BC())), GT()))
-        @test @inferred(indices(itp2)) === indices(A2)
+        @test @inferred(axes(itp2)) === axes(A2)
         for j = first(yinds)+inset:last(yinds)-inset, i = first(xinds)+inset:last(xinds)-inset
             @test itp2[i,j] ≈ A2[i,j]
         end
@@ -56,7 +57,7 @@ for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
 
     for BC in (Flat,Line,Free,Periodic), GT in (OnGrid, OnCell)
         itp1 = @inferred(constructor(copier(A1), BSpline(Cubic(BC())), GT()))
-        @test @inferred(indices(itp1)) === indices(A1)
+        @test @inferred(axes(itp1)) === axes(A1)
 
         # test that we reproduce the values at on-grid points
         inset = constructor == interpolate!
@@ -65,7 +66,7 @@ for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
         end
 
         itp2 = @inferred(constructor(copier(A2), BSpline(Cubic(BC())), GT()))
-        @test @inferred(indices(itp2)) === indices(A2)
+        @test @inferred(axes(itp2)) === axes(A2)
         for j = first(yinds)+inset:last(yinds)-inset, i = first(xinds)+inset:last(xinds)-inset
             @test itp2[i,j] ≈ A2[i,j]
         end

--- a/test/b-splines/quadratic.jl
+++ b/test/b-splines/quadratic.jl
@@ -1,6 +1,6 @@
 module QuadraticTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
 
 for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
     f(x) = sin((x-3)*2pi/9 - 1)

--- a/test/convenience-constructors.jl
+++ b/test/convenience-constructors.jl
@@ -1,7 +1,7 @@
 ﻿module ConvenienceConstructorTests
 
 using Interpolations
-using Base.Test
+using Compat.Test
 using Base.Cartesian
 
 # unit test setup

--- a/test/extrapolation/function-call-syntax.jl
+++ b/test/extrapolation/function-call-syntax.jl
@@ -1,6 +1,6 @@
 module ExtrapFunctionCallSyntax
 
-using Base.Test, Interpolations, DualNumbers
+using Compat.Test, Interpolations, DualNumbers
 
 # Test if extrapolation by function syntax yields identical results
 f(x) = sin((x-3)*2pi/9 - 1)

--- a/test/extrapolation/non1.jl
+++ b/test/extrapolation/non1.jl
@@ -1,6 +1,6 @@
 module ExtrapNon1
 
-using Base.Test, Interpolations, OffsetArrays
+using Compat.Test, Interpolations, OffsetArrays
 
 f(x) = sin((x-3)*2pi/9 - 1)
 xinds = -3:6

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -1,6 +1,6 @@
 module ExtrapTests
 
-using Base.Test, DualNumbers
+using Compat.Test, DualNumbers
 using Interpolations
 
 
@@ -92,7 +92,7 @@ for E in [0,Flat(),Linear(),Periodic(),Reflect()]
 end
 
 # Issue #156
-F     = *(collect(1.:10.), collect(1:4)')
+F     = *(collect(1.0:10.0), collect(1:4)')
 itp   = interpolate(F, (BSpline(Linear()), NoInterp()), OnGrid());
 itps   = scale(itp, 1:10, 1:4)
 itpe   = extrapolate(itps, (Linear(), Interpolations.Throw()))

--- a/test/extrapolation/type-stability.jl
+++ b/test/extrapolation/type-stability.jl
@@ -1,6 +1,6 @@
 module ExtrapTypeStability
 
-using Base.Test, Interpolations, DualNumbers
+using Compat.Test, Interpolations, DualNumbers
 
 # Test type-stability of 1-dimensional extrapolation
 f(x) = sin((x-3)*2pi/9 - 1)
@@ -53,8 +53,8 @@ end
 A = [1 2; 3 4]
 Af = Float64.(A)
 for B in (A, Af)
-    itpg = interpolate(B, BSpline(Linear()), OnGrid())
-    etp = extrapolate(itpg, NaN)
+    itpg2 = interpolate(B, BSpline(Linear()), OnGrid())
+    etp = extrapolate(itpg2, NaN)
     @test typeof(@inferred(getindex(etp, dual(1.5,1), dual(1.5,1)))) ==
           typeof(@inferred(getindex(etp, dual(6.5,1), dual(3.5,1))))
 end

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -1,6 +1,6 @@
 module GradientTests
 
-using Base.Test, Interpolations, DualNumbers
+using Compat, Compat.Test, Interpolations, DualNumbers, Compat.LinearAlgebra
 
 nx = 10
 f1(x) = sin((x-3)*2pi/(nx-1) - 1)
@@ -10,7 +10,7 @@ g1(x) = 2pi/(nx-1) * cos((x-3)*2pi/(nx-1) - 1)
 itp1 = interpolate(Float64[f1(x) for x in 1:nx-1],
             BSpline(Constant()), OnGrid())
 
-g = Array{Float64}( 1)
+g = Array{Float64}(undef, 1)
 
 for x in 1:nx
     @test gradient(itp1, x)[1] == 0
@@ -71,8 +71,8 @@ end
 c = 2.3
 a = 8.1
 o = 1.6
-qfunc = x -> a*(x-c).^2 + o
-dqfunc = x -> 2*a*(x-c)
+qfunc = x -> a*(x .- c).^2 .+ o
+dqfunc = x -> 2*a*(x .- c)
 xg = Float64[1:5;]
 y = qfunc(xg)
 
@@ -114,6 +114,7 @@ for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
     itp_d = interpolate(A2, (BSpline(Quadratic(BC())), NoInterp()), GT())
 
     for i = 1:10
+        global x, y
         x = rand()*(nx-2)+1.5
         y = rand()*(nx-2)+1.5
         xd = dual(x, 1)

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -1,6 +1,6 @@
 module GridTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
 
 # On-grid values
 A = randn(4,10)

--- a/test/gridded/function-call-syntax.jl
+++ b/test/gridded/function-call-syntax.jl
@@ -1,11 +1,12 @@
 module GriddedFunctionCallSyntax
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
+using Compat: range
 
 for D in (Constant, Linear), G in (OnCell, OnGrid)
     ## 1D
     a = rand(5)
-    knots = (collect(linspace(1,length(a),length(a))),)
+    knots = (collect(range(1, stop=length(a), length=length(a))),)
     itp = @inferred(interpolate(knots, a, Gridded(D())))
     @inferred(getindex(itp, 2))
     @inferred(getindex(itp, CartesianIndex((2,))))
@@ -16,7 +17,7 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     @inferred(getindex(itp, knots...))
     @test itp[knots...] ≈ a
     # compare scalar indexing and vector indexing
-    x = knots[1]+0.1
+    x = knots[1] .+ 0.1
     v = itp(x)
     for i = 1:length(x)
         @test v[i] ≈ itp(x[i])
@@ -29,13 +30,13 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     end
     # compare against BSpline
     itpb = @inferred(interpolate(a, BSpline(D()), G()))
-    for x in linspace(1.1,4.9,101)
+    for x in range(1.1, stop=4.9, length=101)
         @test itp(x) ≈ itpb(x)
     end
 
     ## 2D
     A = rand(6,5)
-    knots = (collect(linspace(1,size(A,1),size(A,1))),collect(linspace(1,size(A,2),size(A,2))))
+    knots = (collect(range(1, stop=size(A,1), length=size(A,1))),collect(range(1, stop=size(A,2), length=size(A,2))))
     itp = @inferred(interpolate(knots, A, Gridded(D())))
     @test parent(itp) === A
     @inferred(getindex(itp, 2, 2))
@@ -47,7 +48,7 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     @test itp[knots...] ≈ A
     @inferred(getindex(itp, knots...))
     # compare scalar indexing and vector indexing
-    x, y = knots[1]+0.1, knots[2]+0.6
+    x, y = knots[1] .+ 0.1, knots[2] .+ 0.6
     v = itp(x,y)
     for j = 1:length(y), i = 1:length(x)
         @test v[i,j] ≈ itp(x[i],y[j])
@@ -61,7 +62,7 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     end
     # compare against BSpline
     itpb = @inferred(interpolate(A, BSpline(D()), G()))
-    for y in linspace(1.1,5.9,101), x in linspace(1.1,4.9,101)
+    for y in range(1.1, stop=5.9, length=101), x in range(1.1, stop=4.9, length=101)
         @test itp(x,y) ≈ itpb(x,y)
     end
 

--- a/test/gridded/gridded.jl
+++ b/test/gridded/gridded.jl
@@ -1,11 +1,12 @@
 module LinearTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
+using Compat: range
 
 for D in (Constant, Linear), G in (OnCell, OnGrid)
     ## 1D
     a = rand(5)
-    knots = (collect(linspace(1,length(a),length(a))),)
+    knots = (collect(range(1, stop=length(a), length=length(a))),)
     itp = @inferred(interpolate(knots, a, Gridded(D())))
     @inferred(getindex(itp, 2))
     @inferred(getindex(itp, CartesianIndex((2,))))
@@ -16,7 +17,7 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     @inferred(getindex(itp, knots...))
     @test itp[knots...] ≈ a
     # compare scalar indexing and vector indexing
-    x = knots[1]+0.1
+    x = knots[1] .+ 0.1
     v = itp[x]
     for i = 1:length(x)
         @test v[i] ≈ itp[x[i]]
@@ -29,13 +30,13 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     end
     # compare against BSpline
     itpb = @inferred(interpolate(a, BSpline(D()), G()))
-    for x in linspace(1.1,4.9,101)
+    for x in range(1.1, stop=4.9, length=101)
         @test itp[x] ≈ itpb[x]
     end
 
     ## 2D
     A = rand(6,5)
-    knots = (collect(linspace(1,size(A,1),size(A,1))),collect(linspace(1,size(A,2),size(A,2))))
+    knots = (collect(range(1, stop=size(A,1), length=size(A,1))),collect(range(1, stop=size(A,2), length=size(A,2))))
     itp = @inferred(interpolate(knots, A, Gridded(D())))
     @test parent(itp) === A
     @inferred(getindex(itp, 2, 2))
@@ -47,7 +48,7 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     @test itp[knots...] ≈ A
     @inferred(getindex(itp, knots...))
     # compare scalar indexing and vector indexing
-    x, y = knots[1]+0.1, knots[2]+0.6
+    x, y = knots[1] .+ 0.1, knots[2] .+ 0.6
     v = itp[x,y]
     for j = 1:length(y), i = 1:length(x)
         @test v[i,j] ≈ itp[x[i],y[j]]
@@ -61,7 +62,7 @@ for D in (Constant, Linear), G in (OnCell, OnGrid)
     end
     # compare against BSpline
     itpb = @inferred(interpolate(A, BSpline(D()), G()))
-    for y in linspace(1.1,5.9,101), x in linspace(1.1,4.9,101)
+    for y in range(1.1, stop=5.9, length=101), x in range(1.1, stop=4.9, length=101)
         @test itp[x,y] ≈ itpb[x,y]
     end
 

--- a/test/gridded/mixed.jl
+++ b/test/gridded/mixed.jl
@@ -1,9 +1,10 @@
 module MixedTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
+using Compat: range
 
 A = rand(6,5)
-knots = (collect(linspace(1,size(A,1),size(A,1))),collect(linspace(1,size(A,2),size(A,2))))
+knots = (collect(range(1, stop=size(A,1), length=size(A,1))),collect(range(1, stop=size(A,2), length=size(A,2))))
 itp = @inferred(interpolate(knots, A, (Gridded(Linear()),NoInterp())))
 @inferred(getindex(itp, 2, 2))
 @inferred(getindex(itp, CartesianIndex((2,2))))

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,6 +1,6 @@
 module IOTests
 
-using Base.Test
+using Compat.Test
 using Interpolations
 
 SPACE = " "

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -1,6 +1,6 @@
 module Issue34
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
 
 A = rand(1:20, 100, 100)
 

--- a/test/linear.jl
+++ b/test/linear.jl
@@ -1,7 +1,6 @@
-
 module Linear1DTests
 println("Testing Linear interpolation in 1D...")
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
 
 f(x) = sin((x-3)*2pi/9 - 1)
 xmax = 10

--- a/test/nointerp.jl
+++ b/test/nointerp.jl
@@ -1,6 +1,6 @@
 module NoInterpTests
 println("Testing NoInterp...")
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
 
 a = reshape(1:12, 3, 4)
 ai = interpolate(a, NoInterp(), OnGrid())

--- a/test/on-grid.jl
+++ b/test/on-grid.jl
@@ -1,7 +1,6 @@
-
 module OnGridTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
 
 nx, ny, nz = 10, 8, 9
 xg, yg, zg = 1:nx, 1:ny, 1:nz
@@ -19,7 +18,7 @@ function OneD()
     println("Testing evaluation on grid and boundary in 1D...")
     for deg in simpledegs, gb in gridbehvs
         fg = Float64[f1(x) for x in xg]
-        
+
         itp = Interpolation(fg, deg(gb()), ExtrapError())
 
         for i in xg

--- a/test/readme-examples.jl
+++ b/test/readme-examples.jl
@@ -1,6 +1,6 @@
 module ReadmeExampleTests
-# verify examples from README.md run 
-using Interpolations, Base.Test
+# verify examples from README.md run
+using Interpolations, Compat.Test
 
 ## Bsplines
 a = randn(5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 module RunTests
 
-using Base.Test
+using Compat.Test
 using Interpolations
 
 
@@ -23,11 +23,11 @@ include("gridded/runtests.jl")
 include("typing.jl")
 
 # Tests copied from Grid.jl's old test suite
-#include("grid.jl")
+# include("grid.jl")
 
 include("issues/runtests.jl")
 
-include("io.jl")
+# include("io.jl")
 include("convenience-constructors.jl")
 include("readme-examples.jl")
 

--- a/test/scaling/dimspecs.jl
+++ b/test/scaling/dimspecs.jl
@@ -1,6 +1,6 @@
 module ScalingDimspecTests
 
-using Interpolations, DualNumbers, Base.Test
+using Interpolations, DualNumbers, Compat.Test, Compat.LinearAlgebra
 
 xs = -pi:(2pi/10):pi-2pi/10
 ys = -2:.1:2

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -1,6 +1,7 @@
 module ScalingNoInterpTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test, Compat.LinearAlgebra, Compat.Random
+using Compat: range
 
 xs = -pi:2pi/10:pi
 f1(x) = sin(x)
@@ -30,7 +31,7 @@ zb = copy(z0')
 itpa = interpolate(za, (BSpline(Linear()), NoInterp()), OnGrid())
 itpb = interpolate(zb, (NoInterp(), BSpline(Linear())), OnGrid())
 
-rng = linspace(1.0, 19.0, 10)
+rng = range(1.0, stop=19.0, length=10)
 sitpa = scale(itpa, rng, 1:10)
 sitpb = scale(itpb, 1:10, rng)
 @test gradient(sitpa, 3.0, 3) ==  gradient(sitpb, 3, 3.0)

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -1,7 +1,7 @@
 module ScalingTests
 
-using Interpolations
-using Base.Test
+using Interpolations, Compat
+using Compat.Test, Compat.LinearAlgebra
 
 # Model linear interpolation of y = -3 + .5x by interpolating y=x
 # and then scaling to the new x range
@@ -57,9 +57,27 @@ knots = map(d->1:10:21, 1:3)
 sitp = @inferred scale(itp, knots...)
 
 iter = @inferred(eachvalue(sitp))
-state = @inferred(start(iter))
-@test !(@inferred(done(iter, state)))
-val, state = @inferred(next(iter, state))
+
+@static if VERSION < v"0.7.0-DEV.5126"
+    state = @inferred(start(iter))
+    @test !(@inferred(done(iter, state)))
+    val, state = @inferred(next(iter, state))
+else
+    iter_next = iterate(iter)
+    @test iter_next isa Tuple
+    @test iter_next[1] isa Float64
+    state = iter_next[2]
+    inferred_next = Base.return_types(iterate, (typeof(iter),))
+    @test length(inferred_next) == 1
+    @test inferred_next[1] == Union{Nothing,Tuple{Float64,typeof(state)}}
+    iter_next = iterate(iter, state)
+    @test iter_next isa Tuple
+    @test iter_next[1] isa Float64
+    inferred_next = Base.return_types(iterate, (typeof(iter),typeof(state)))
+    state = iter_next[2]
+    @test length(inferred_next) == 1
+    @test inferred_next[1] == Union{Nothing,Tuple{Float64,typeof(state)}}
+end
 
 function foo!(dest, sitp)
     i = 0
@@ -69,12 +87,12 @@ function foo!(dest, sitp)
     dest
 end
 function bar!(dest, sitp)
-    for I in CartesianRange(size(dest))
+    for I in CartesianIndices(size(dest))
         dest[I] = sitp[I]
     end
     dest
 end
-rfoo = Array{Float64}( Interpolations.ssize(sitp))
+rfoo = Array{Float64}(undef, Interpolations.ssize(sitp))
 rbar = similar(rfoo)
 foo!(rfoo, sitp)
 bar!(rbar, sitp)

--- a/test/scaling/withextrap.jl
+++ b/test/scaling/withextrap.jl
@@ -1,9 +1,9 @@
-
 module ScalingWithExtrapTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
+using Compat: range
 
-xs = linspace(-5, 5, 10)
+xs = range(-5, stop=5, length=10)
 ys = map(sin, xs)
 
 function run_tests(sut::Interpolations.AbstractInterpolation{T,N,IT,OnGrid}, itp) where {T,N,IT}

--- a/test/type-instantiation.jl
+++ b/test/type-instantiation.jl
@@ -1,6 +1,6 @@
 module TypeInstantiationTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test
 
 # NO DIMSPECS
 # tests that we forward types correctly to the instance constructors

--- a/test/typing.jl
+++ b/test/typing.jl
@@ -1,6 +1,6 @@
 module TypingTests
 
-using Interpolations, Base.Test
+using Interpolations, Compat.Test, Compat.LinearAlgebra
 
 nx = 10
 f(x) = convert(Float32, x^3/(nx-1))


### PR DESCRIPTION
(Note that this relies on https://github.com/timholy/AxisAlgorithms.jl/pull/11.)
This fixes all errors and deprecation warnings on 0.7, except for the IO part, whose tests are disabled. The objects are simply printed differently on 0.7, e.g. instead of
```
"8×20 interpolate(::Array{Float64,2}, BSpline(Constant()), OnCell()) with element type Float64"
```
you get
```
"8×20 Interpolations.BSplineInterpolation{Float64,2,Array{Float64,2},Interpolations.BSpline{Interpolations.Constant},Interpolations.OnCell,0}" == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant()), OnCell()) with element type Float64"
```
I suspect that the problem there may be with the ShowitLikeYouBuildIt package, but I haven't investigated thoroughly.
In any case, this PR is probably large enough as it is, and the IO problems might be solved at a later time.

The main thing to note about this PR is that it can expose what I believe is a bug in Julia 0.7-beta during the inference of some `getindex` generated functions. To make things work here, I have had to define some specialized methods for `index_gen` which shouldn't really be necessary (everything works fine without them on 0.6, but on 0.7 despite the fact that `index_gen` works correctly by itself, its inference triggers an "unexpected runtime error" in julia). All these extra methods are marked with "FIXME" comments. This should then be reported as a bug in julia, and the methods removed when it's fixed.

I have also removed a deprecated `Extrapolation` constructor since I assume this will be a new minor version. It's easy to put it back in though.
