### PR TITLE
add 0.7-compatible showarg methods

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -1,3 +1,5 @@
+# after this, functionality was incorporated into Base
+if VERSION < v"0.7.0-DEV.1790"
 using ShowItLikeYouBuildIt
 
 Base.summary(A::AbstractInterpolation) = summary_build(A)
@@ -51,6 +53,78 @@ function ShowItLikeYouBuildIt.showarg(io::IO, A::FilledExtrapolation{T,N,TI,IT,G
     print(io, "extrapolate(")
     showarg(io, A.itp)
     print(io, ", ", A.fillvalue, ')')
+end
+
+else
+
+function Base.showarg(io::IO, A::BSplineInterpolation{T,N,TW,ST,GT}, toplevel) where {T,N,TW,ST,GT}
+    print(io, "interpolate(")
+    Base.showarg(io, A.coefs, false)
+    print(io, ", ")
+    _showtypeparam(io, ST)
+    print(io, ", ")
+    _showtypeparam(io, GT)
+    if toplevel
+        print(io, ") with element type ",T)
+    else
+        print(io, ')')
+    end
+end
+
+function Base.showarg(io::IO, A::GriddedInterpolation{T,N,TC,ST,K}, toplevel) where {T,N,TC,ST,K}
+    print(io, "interpolate(")
+    _showknots(io, A.knots)
+    print(io, ", ")
+    Base.showarg(io, A.coefs, false)
+    print(io, ", ")
+    _showtypeparam(io, ST)
+    if toplevel
+        print(io, ") with element type ",T)
+    else
+        print(io, ')')
+    end
+end
+
+_showknots(io, A) = Base.showarg(io, A, false)
+function _showknots(io, tup::NTuple{N,Any}) where N
+    print(io, '(')
+    for (i, A) in enumerate(tup)
+        Base.showarg(io, A, false)
+        i < N && print(io, ',')
+    end
+    N == 1 && print(io, ',')
+    print(io, ')')
+end
+
+function Base.showarg(io::IO, A::ScaledInterpolation{T}, toplevel) where {T}
+    print(io, "scale(")
+    Base.showarg(io, A.itp, false)
+    print(io, ", ", A.ranges, ')')
+    if toplevel
+        print(io, " with element type ",T)
+    end
+end
+
+function Base.showarg(io::IO, A::Extrapolation{T,N,TI,IT,GT,ET}, toplevel) where {T,N,TI,IT,GT,ET}
+    print(io, "extrapolate(")
+    Base.showarg(io, A.itp, false)
+    print(io, ", ")
+    _showtypeparam(io, ET)
+    print(io, ')')
+    if toplevel
+        print(io, " with element type ",T)
+    end
+end
+
+function Base.showarg(io::IO, A::FilledExtrapolation{T,N,TI,IT,GT}, toplevel) where {T,N,TI,IT,GT}
+    print(io, "extrapolate(")
+    Base.showarg(io, A.itp, false)
+    print(io, ", ", A.fillvalue, ')')
+    if toplevel
+        print(io, " with element type ",T)
+    end
+end
+
 end
 
 _showtypeparam(io, ::Type{T}) where {T} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ include("typing.jl")
 
 include("issues/runtests.jl")
 
-# include("io.jl")
+include("io.jl")
 include("convenience-constructors.jl")
 include("readme-examples.jl")
 


### PR DESCRIPTION
This change adds versions of the `showarg` methods compatible with the usage in 0.7 `Base`.
The old `ShowItLikeYouBuildIt` versions are still used with older Julia.
Output format is the same as in the earlier versions of Interpolations.
Corresponding tests are re-enabled.