### PR TITLE
Fix testing failure on julia 1.0

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -8,6 +8,7 @@ export
     extrapolate,
     scale,
 
+    gradient,
     gradient!,
     gradient1,
     hessian!,

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -46,8 +46,6 @@ import Base: convert, size, getindex, promote_rule,
 
 @static if VERSION < v"0.7.0-DEV.3449"
     import Base: gradient
-else
-    import LinearAlgebra: gradient
 end
 
 import Compat: axes

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -23,7 +23,9 @@ end
 @test length(gradient(sitp, pi/3, 2)) == 1
 
 # check for case where initial/middle indices are NoInterp but later ones are <:BSpline
-srand(1234)
+
+isdefined(Random, :seed!) ? Random.seed!(1234) : srand(1234) # `srand` was renamed to `seed!` 
+
 z0 = rand(10,10)
 za = copy(z0)
 zb = copy(z0')


### PR DESCRIPTION
This removes the import of LinearAlgebra: gradient  and exports the gradient function because it has been fully removed (see https://github.com/JuliaLang/julia/issues/16113).
It also includes the changes of #221 to Random.srand.