### PR TITLE
BREAKING: Unexport gradient and friends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 julia:
     - 0.6
     - 0.7
+    - 1.0
     - nightly
 matrix:
     allow_failures:

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -8,12 +8,6 @@ export
     extrapolate,
     scale,
 
-    gradient!,
-    gradient1,
-    hessian!,
-    hessian,
-    hessian1,
-
     AbstractInterpolation,
     AbstractExtrapolation,
 
@@ -47,7 +41,7 @@ import Base: convert, size, getindex, promote_rule,
 @static if VERSION < v"0.7.0-DEV.3449"
     import Base: gradient
 else
-    import LinearAlgebra: gradient
+    function gradient end
 end
 
 import Compat: axes

--- a/test/b-splines/cubic.jl
+++ b/test/b-splines/cubic.jl
@@ -71,16 +71,16 @@ for (constructor, copier) in ((interpolate, identity), (interpolate!, copy))
         itp = constructor(copier(A), BSpline(Cubic(BC())), GT())
         # test that inner region is close to data
         for x in range(ix[5], stop=ix[end-4], length=100)
-            @test ≈(g(x),(gradient(itp,x))[1],atol=cbrt(cbrt(eps(g(x)))))
+            @test ≈(g(x),(Interpolations.gradient(itp,x))[1],atol=cbrt(cbrt(eps(g(x)))))
         end
     end
 end
 itp_flat_g = interpolate(A, BSpline(Cubic(Flat())), OnGrid())
-@test ≈((gradient(itp_flat_g,1))[1],0,atol=eps())
-@test ≈((gradient(itp_flat_g,ix[end]))[1],0,atol=eps())
+@test ≈((Interpolations.gradient(itp_flat_g,1))[1],0,atol=eps())
+@test ≈((Interpolations.gradient(itp_flat_g,ix[end]))[1],0,atol=eps())
 
 itp_flat_c = interpolate(A, BSpline(Cubic(Flat())), OnCell())
-@test ≈((gradient(itp_flat_c,0.5))[1],0,atol=eps())
-@test ≈((gradient(itp_flat_c,ix[end] + 0.5))[1],0,atol=eps())
+@test ≈((Interpolations.gradient(itp_flat_c,0.5))[1],0,atol=eps())
+@test ≈((Interpolations.gradient(itp_flat_c,ix[end] + 0.5))[1],0,atol=eps())
 
 end

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -13,8 +13,8 @@ itp1 = interpolate(Float64[f1(x) for x in 1:nx-1],
 g = Array{Float64}(undef, 1)
 
 for x in 1:nx
-    @test gradient(itp1, x)[1] == 0
-    @test gradient!(g, itp1, x)[1] == 0
+    @test Interpolations.gradient(itp1, x)[1] == 0
+    @test Interpolations.gradient!(g, itp1, x)[1] == 0
     @test g[1] == 0
 end
 
@@ -25,14 +25,14 @@ itp2 = interpolate((1:nx-1,), Float64[f1(x) for x in 1:nx-1],
             Gridded(Linear()))
 for itp in (itp1, itp2)
     for x in 2.5:nx-1.5
-        @test ≈(g1(x),(gradient(itp,x))[1],atol=abs(0.1 * g1(x)))
-        @test ≈(g1(x),(gradient!(g,itp,x))[1],atol=abs(0.1 * g1(x)))
+        @test ≈(g1(x),(Interpolations.gradient(itp,x))[1],atol=abs(0.1 * g1(x)))
+        @test ≈(g1(x),(Interpolations.gradient!(g,itp,x))[1],atol=abs(0.1 * g1(x)))
         @test ≈(g1(x),g[1],atol=abs(0.1 * g1(x)))
     end
 
     for i = 1:10
         x = rand()*(nx-2)+1.5
-        gtmp = gradient(itp, x)[1]
+        gtmp = Interpolations.gradient(itp, x)[1]
         xd = dual(x, 1)
         @test epsilon(itp[xd]) ≈ gtmp
     end
@@ -44,8 +44,8 @@ itp_grid = interpolate(knots, Float64[f1(x) for x in knots[1]],
                        Gridded(Linear()))
 
 for x in 1.5:0.5:nx-1.5
-    @test ≈(g1(x),(gradient(itp_grid,x))[1],atol=abs(0.5 * g1(x)))
-    @test ≈(g1(x),(gradient!(g,itp_grid,x))[1],atol=abs(0.5 * g1(x)))
+    @test ≈(g1(x),(Interpolations.gradient(itp_grid,x))[1],atol=abs(0.5 * g1(x)))
+    @test ≈(g1(x),(Interpolations.gradient!(g,itp_grid,x))[1],atol=abs(0.5 * g1(x)))
     @test ≈(g1(x),g[1],atol=abs(0.5 * g1(x)))
 end
 
@@ -53,14 +53,14 @@ end
 itp1 = interpolate(Float64[f1(x) for x in 1:nx-1],
             BSpline(Quadratic(Periodic())), OnCell())
 for x in 2:nx-1
-    @test ≈(g1(x),(gradient(itp1,x))[1],atol=abs(0.05 * g1(x)))
-    @test ≈(g1(x),(gradient!(g,itp1,x))[1],atol=abs(0.05 * g1(x)))
+    @test ≈(g1(x),(Interpolations.gradient(itp1,x))[1],atol=abs(0.05 * g1(x)))
+    @test ≈(g1(x),(Interpolations.gradient!(g,itp1,x))[1],atol=abs(0.05 * g1(x)))
     @test ≈(g1(x),g[1],atol=abs(0.1 * g1(x)))
 end
 
 for i = 1:10
     x = rand()*(nx-2)+1.5
-    gtmp = gradient(itp1, x)[1]
+    gtmp = Interpolations.gradient(itp1, x)[1]
     xd = dual(x, 1)
     @test epsilon(itp1[xd]) ≈ gtmp
 end
@@ -79,7 +79,7 @@ y = qfunc(xg)
 iq = interpolate(y, BSpline(Quadratic(Free())), OnCell())
 x = 1.8
 @test iq[x] ≈ qfunc(x)
-@test (gradient(iq,x))[1] ≈ dqfunc(x)
+@test (Interpolations.gradient(iq,x))[1] ≈ dqfunc(x)
 
 # 2d (biquadratic)
 p = [(x-1.75)^2 for x = 1:7]
@@ -87,14 +87,14 @@ A = p*p'
 iq = interpolate(A, BSpline(Quadratic(Free())), OnCell())
 @test iq[4,4] ≈ (4 - 1.75) ^ 4
 @test iq[4,3] ≈ (4 - 1.75) ^ 2 * (3 - 1.75) ^ 2
-g = gradient(iq, 4, 3)
+g = Interpolations.gradient(iq, 4, 3)
 @test g[1] ≈ 2 * (4 - 1.75) * (3 - 1.75) ^ 2
 @test g[2] ≈ 2 * (4 - 1.75) ^ 2 * (3 - 1.75)
 
 iq = interpolate!(copy(A), BSpline(Quadratic(InPlace())), OnCell())
 @test iq[4,4] ≈ (4 - 1.75) ^ 4
 @test iq[4,3] ≈ (4 - 1.75) ^ 2 * (3 - 1.75) ^ 2
-g = gradient(iq, 4, 3)
+g = Interpolations.gradient(iq, 4, 3)
 @test ≈(g[1],2 * (4 - 1.75) * (3 - 1.75) ^ 2,atol=0.03)
 @test ≈(g[2],2 * (4 - 1.75) ^ 2 * (3 - 1.75),atol=0.2)
 
@@ -102,7 +102,7 @@ g = gradient(iq, 4, 3)
 iq = interpolate!(copy(A), BSpline(Quadratic(InPlaceQ())), OnCell())
 @test iq[4,4] ≈ (4 - 1.75) ^ 4
 @test iq[4,3] ≈ (4 - 1.75) ^ 2 * (3 - 1.75) ^ 2
-g = gradient(iq, 4, 3)
+g = Interpolations.gradient(iq, 4, 3)
 @test g[1] ≈ 2 * (4 - 1.75) * (3 - 1.75) ^ 2
 @test g[2] ≈ 2 * (4 - 1.75) ^ 2 * (3 - 1.75)
 
@@ -119,19 +119,19 @@ for BC in (Flat,Line,Free,Periodic,Reflect,Natural), GT in (OnGrid, OnCell)
         y = rand()*(nx-2)+1.5
         xd = dual(x, 1)
         yd = dual(y, 1)
-        gtmp = gradient(itp_a, x, y)
+        gtmp = Interpolations.gradient(itp_a, x, y)
         @test length(gtmp) == 2
         @test epsilon(itp_a[xd,y]) ≈ gtmp[1]
         @test epsilon(itp_a[x,yd]) ≈ gtmp[2]
-        gtmp = gradient(itp_b, x, y)
+        gtmp = Interpolations.gradient(itp_b, x, y)
         @test length(gtmp) == 2
         @test epsilon(itp_b[xd,y]) ≈ gtmp[1]
         @test epsilon(itp_b[x,yd]) ≈ gtmp[2]
         ix, iy = round(Int, x), round(Int, y)
-        gtmp = gradient(itp_c, ix, y)
+        gtmp = Interpolations.gradient(itp_c, ix, y)
         @test length(gtmp) == 1
         @test epsilon(itp_c[ix,yd]) ≈ gtmp[1]
-        gtmp = gradient(itp_d, x, iy)
+        gtmp = Interpolations.gradient(itp_d, x, iy)
         @test length(gtmp) == 1
         @test epsilon(itp_d[xd,iy]) ≈ gtmp[1]
     end

--- a/test/scaling/dimspecs.jl
+++ b/test/scaling/dimspecs.jl
@@ -12,7 +12,7 @@ sitp = scale(itp, xs, ys)
 for (ix,x) in enumerate(xs), (iy,y) in enumerate(ys)
     @test ≈(sitp[x,y],f(x,y),atol=sqrt(eps(1.0)))
 
-    g = gradient(sitp, x, y)
+    g = Interpolations.gradient(sitp, x, y)
     fx = epsilon(sitp[dual(x,1), dual(y,0)])
     fy = epsilon(sitp[dual(x,0), dual(y,1)])
 

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -20,7 +20,7 @@ for (ix,x0) in enumerate(xs[1:end-1]), y0 in ys
     @test ≈(sitp[x,y],f(x,y),atol=0.05)
 end
 
-@test length(gradient(sitp, pi/3, 2)) == 1
+@test length(Interpolations.gradient(sitp, pi/3, 2)) == 1
 
 # check for case where initial/middle indices are NoInterp but later ones are <:BSpline
 isdefined(Random, :seed!) ? Random.seed!(1234) : srand(1234) # `srand` was renamed to `seed!`
@@ -34,6 +34,6 @@ itpb = interpolate(zb, (NoInterp(), BSpline(Linear())), OnGrid())
 rng = range(1.0, stop=19.0, length=10)
 sitpa = scale(itpa, rng, 1:10)
 sitpb = scale(itpb, 1:10, rng)
-@test gradient(sitpa, 3.0, 3) ==  gradient(sitpb, 3, 3.0)
+@test Interpolations.gradient(sitpa, 3.0, 3) ==  Interpolations.gradient(sitpb, 3, 3.0)
 
 end

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -39,7 +39,7 @@ itp = interpolate(ys, BSpline(Linear()), OnGrid())
 sitp = @inferred scale(itp, xs)
 
 for x in -pi:.1:pi
-    g = @inferred(gradient(sitp, x))[1]
+    g = @inferred(Interpolations.gradient(sitp, x))[1]
     @test ≈(cos(x),g,atol=0.05)
 end
 

--- a/test/typing.jl
+++ b/test/typing.jl
@@ -22,10 +22,10 @@ end
 @test typeof(itp[3.5f0]) == Float32
 
 for x in 3.1:.2:4.3
-    @test ≈([g(x)], gradient(itp,x),atol=abs(0.1 * g(x)))
+    @test ≈([g(x)], Interpolations.gradient(itp,x),atol=abs(0.1 * g(x)))
 end
 
-@test typeof(gradient(itp, 3.5f0)[1]) == Float32
+@test typeof(Interpolations.gradient(itp, 3.5f0)[1]) == Float32
 
 # Rational element types
 R = Rational{Int}[x^2//10 for x in 1:10]


### PR DESCRIPTION
This is another take on solving the same problems as #222, but instead of exporting a new function `gradient`, I have removed it (and its friends) from the list of exported functions.

By qualifying all usages in the test suite as `Interpolations.gradient`, they now pass on 1.0! 🎉 

However, I'd like to figure out a way to make this transition a little kinder to the users. Is there a way to deprecate usage like
```
using Interpolations
itp = ...
gradient(itp, ...)
```
while still allowing
```
using Interpolations
itp = ...
Interpolations.gradient(itp, ...)
```
?

If not, maybe we just have to accept that this is part of a somewhat painful transition to 1.0.

Edit: I've incorporated #223 here too, because making it work on Julia 1.0 is the main motivation behind this PR. Doesn't matter to me if we merge #223 first and then this (which will effectively rebase that commit away) or close #223 and take the change from here.

---

Side note: It's not so weird to me after making these changes that we have problems with Hessians (se e.g. #122 and #181). There's not a single mention of `hessian` in the test suite...