### PR TITLE
Define fallbacks for `gradient!` and `hessian!` (fixes #239)

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -348,11 +348,17 @@ function gradient(itp::AbstractInterpolation, x::Vararg{UnexpandedIndexTypes})
     xi == x && error("gradient of $itp not supported for position $x")
     gradient(itp, xi...)
 end
+@propagate_inbounds function gradient!(dest, itp::AbstractInterpolation{T,N}, x::Vararg{Number,N}) where {T,N}
+    dest .= gradient(itp, x...)
+end
 function gradient!(dest, itp::AbstractInterpolation, x::Vararg{UnexpandedIndexTypes})
     gradient!(dest, itp, to_indices(itp, x)...)
 end
 function hessian(itp::AbstractInterpolation, x::Vararg{UnexpandedIndexTypes})
     hessian(itp, to_indices(itp, x)...)
+end
+@propagate_inbounds function hessian!(dest, itp::AbstractInterpolation{T,N}, x::Vararg{Number,N}) where {T,N}
+    dest .= hessian(itp, x...)
 end
 function hessian!(dest, itp::AbstractInterpolation, x::Vararg{UnexpandedIndexTypes})
     hessian!(dest, itp, to_indices(itp, x)...)

--- a/src/gridded/indexing.jl
+++ b/src/gridded/indexing.jl
@@ -13,9 +13,6 @@ end
     wis = weightedindexes((value_weights, gradient_weights), itpinfo(itp)..., x)
     SVector(map(inds->coefficients(itp)[inds...], wis))
 end
-@propagate_inbounds function gradient!(dest, itp::GriddedInterpolation{T,N}, x::Vararg{Number,N}) where {T,N}
-    dest .= gradient(itp, x...)
-end
 
 itpinfo(itp::GriddedInterpolation) = (tcollect(itpflag, itp), itp.knots)
 

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -163,4 +163,13 @@ using Test, Interpolations, DualNumbers, LinearAlgebra
         end
     end
 
+    # issue #239
+    f(x) = log(x)
+    xs = 1:0.2:5
+    A = [f(x) for x in xs]
+    interp_linear = LinearInterpolation(xs, A)
+    g = Interpolations.gradient(interp_linear, 1.5)
+    dest = Vector{Float64}(undef, 1)
+    Interpolations.gradient!(dest, interp_linear, 1.5)
+    @test dest == g
 end


### PR DESCRIPTION
It's possible that more efficient variants are possible, but really I'd expect that returning the SVector/SMatrix is as good as it gets, so having these as generic fallbacks makes sense.