### PR TITLE
Support for Flat, Line and Throw extrapolations for monotonic interpolation

### DIFF
--- a/src/monotonic/monotonic.jl
+++ b/src/monotonic/monotonic.jl
@@ -122,6 +122,8 @@ end
 size(A::MonotonicInterpolation) = size(A.knots)
 axes(A::MonotonicInterpolation) = axes(A.knots)
 
+itpflag(A::MonotonicInterpolation) = A.it
+
 function MonotonicInterpolation(::Type{TWeights}, it::TInterpolationType, knots::TKnots, A::AbstractArray{TEl,1},
     m::Vector{TCoeffs}, c::Vector{TCoeffs}, d::Vector{TCoeffs}) where {TWeights, TCoeffs, TEl, TInterpolationType<:MonotonicInterpolationType, TKnots<:AbstractVector{<:Number}}
 

--- a/test/monotonic/runtests.jl
+++ b/test/monotonic/runtests.jl
@@ -38,6 +38,15 @@ using Interpolations
                     end
                 end
             end
+            extFlatItp = extrapolate(itp, Flat())
+            @test extFlatItp(x[1]-1) ≈ itp(x[1])
+            @test extFlatItp(x[end]+1) ≈ itp(x[end])
+            extThrowItp = extrapolate(itp, Throw())
+            @test_throws BoundsError extThrowItp(x[1]-1)
+            @test_throws BoundsError extThrowItp(x[end]+1)
+            extLineItp = extrapolate(itp, Line())
+            @test extLineItp(x[1]-1) ≈ itp(x[1]) - Interpolations.gradient1(itp, x[1])
+            @test extLineItp(x[end]+1) ≈ itp(x[end]) + Interpolations.gradient1(itp, x[end])
         end
     end
 

--- a/test/monotonic/runtests.jl
+++ b/test/monotonic/runtests.jl
@@ -47,6 +47,12 @@ using Interpolations
             extLineItp = extrapolate(itp, Line())
             @test extLineItp(x[1]-1) ≈ itp(x[1]) - Interpolations.gradient1(itp, x[1])
             @test extLineItp(x[end]+1) ≈ itp(x[end]) + Interpolations.gradient1(itp, x[end])
+            extReflectItp = extrapolate(itp, Reflect())
+            @test extReflectItp(x[1]-0.1) ≈ itp(x[1]+0.1)
+            @test extReflectItp(x[end]+0.1) ≈ itp(x[end]-0.1)
+            extPeriodicItp = extrapolate(itp, Periodic())
+            @test extPeriodicItp(x[1]-0.1) ≈ itp(x[end]-0.1)
+            @test extPeriodicItp(x[end]+0.1) ≈ itp(x[1]+0.1)
         end
     end
 


### PR DESCRIPTION
I've encountered some round-off errors, so I think it would be a good idea to support extrapolations for monotonic interpolations.