### PR TITLE
Check ranges passed to scale (fixes #261)

### DIFF
--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -33,7 +33,7 @@ check_ranges(::Any, ::Tuple{}, ::Tuple{}) = nothing
 
 check_range(::NoInterp, ax, r) = ax == r || throw(ArgumentError("The range $r did not equal the corresponding axis of the interpolation object $ax"))
 check_range(::Any, ax, r) = length(ax) == length(r) || throw(ArgumentError("The range $r is incommensurate with the corresponding axis $ax"))
-check_range(r::AbstractRange) = step(r) > zero(eltype(r)) || throw(ArgumentError("The range $r is decreasing"))
+check_range(r::AbstractRange) = step(r) > zero(eltype(r)) || throw(ArgumentError("The range $r is in decreasing order; only ranges with positive steps are supported by scale()."))
 
 # With regards to size and [], ScaledInterpolation behaves like the underlying interpolation object
 size(sitp::ScaledInterpolation) = size(sitp.itp)

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -26,12 +26,14 @@ end
 
 function check_ranges(flags, axs, ranges)
     check_range(getfirst(flags), axs[1], ranges[1])
+    check_range(ranges[1])
     check_ranges(getrest(flags), Base.tail(axs), Base.tail(ranges))
 end
 check_ranges(::Any, ::Tuple{}, ::Tuple{}) = nothing
 
 check_range(::NoInterp, ax, r) = ax == r || throw(ArgumentError("The range $r did not equal the corresponding axis of the interpolation object $ax"))
 check_range(::Any, ax, r) = length(ax) == length(r) || throw(ArgumentError("The range $r is incommensurate with the corresponding axis $ax"))
+check_range(r::AbstractRange) = step(r) > zero(eltype(r)) || throw(ArgumentError("The range $r is decreasing"))
 
 # With regards to size and [], ScaledInterpolation behaves like the underlying interpolation object
 size(sitp::ScaledInterpolation) = size(sitp.itp)

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -15,6 +15,8 @@ using Test, LinearAlgebra
         @test sitp(x) ≈ y
     end
 
+    @test_throws ArgumentError scale(itp, reverse(-3:.5:1.5))
+
     # Verify that it works in >1D, with different types of ranges
 
     gauss(phi, mu, sigma) = exp(-(phi-mu)^2 / (2sigma)^2)


### PR DESCRIPTION
Check that the ranges passed to `scale` are in increasing order (step > 0). I'd appreciate feedback on the error message. Other ideas were `"The range $r is in decreasing order"` and `"The step of range $r is less than zero"`. I didn't add any tests since I didn't see any for the other `check_range` methods, but I can if desired.