### PR TITLE
[RFC] Add Hessians for ScaledInterpolation and tests

### DIFF
--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -67,6 +67,25 @@ end
     end
 end
 
+@inline function hessian(etp::AbstractExtrapolation{T,N}, x::Vararg{Number,N}) where {T,N}
+    itp = parent(etp)
+    if checkbounds(Bool, itp, x...)
+        hessian(itp, x...)
+    else
+        error("extrapolation of hessian not yet implemented")
+        # # copied from gradient above, with obvious modifications
+        # # but final part is missing
+        # eflag = tcollect(etpflag, etp)
+        # xs = inbounds_position(eflag, bounds(itp), x, etp, x)
+        # h = @inbounds hessian(itp, xs...)
+        # skipni = t->skip_flagged_nointerp(itp, t)
+        # # not sure if it should be just h here instead of Tuple(h)
+        # # extrapolate_hessian needs to be written
+        # # SVector is likely also wrong here
+        # SVector(extrapolate_hessian.(skipni(eflag), skipni(x), skipni(xs), Tuple(h)))
+    end
+end
+
 checkbounds(::Bool, ::AbstractExtrapolation, I...) = true
 
 # The last two arguments are just for error-reporting

--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -135,16 +135,18 @@ end
 
 function rescale_hessian_components(flags, ranges, h, n)
     hs = ()
-    for i=1:n
+    idx = 1
+    while idx <= n
         if getfirst(flags) isa NoInterp
             flags = getrest(flags)
             ranges = Base.tail(ranges)
         else
-            s1 = rescale_gradient_components(flags, ranges, Tuple(h[i*(n+1)-n:i*n]))
+            s1 = rescale_gradient_components(flags, ranges, Tuple(h[(idx-1)*n+idx:idx*n]))
             s2 = rescale_hessian(ranges[1], s1)
             hs = (hs..., s2...)
             flags = getrest(flags)
             ranges = Base.tail(ranges)
+            idx += 1
         end
     end
     return hs

--- a/test/hessian.jl
+++ b/test/hessian.jl
@@ -41,6 +41,7 @@ using Test, Interpolations, LinearAlgebra, ForwardDiff
     itp = interpolate(A2, (BSpline(Quadratic(Flat(OnCell()))), NoInterp()))
     v = A2[:, 2]
     itpcol = interpolate(v, BSpline(Quadratic(Flat(OnCell()))))
+    @inferred(Interpolations.hessian(itp, 3.2, 2))
     @test Interpolations.hessian(itp, 3.2, 2) == Interpolations.hessian(itpcol, 3.2)
 
 

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -4,7 +4,7 @@ using Interpolations, Test, LinearAlgebra, Random
     xs = -pi:2pi/10:pi
     f1(x) = sin(x)
     f2(x) = cos(x)
-    f3(x) = sin(x) .* cos(x)
+    f3(x) = sin(x) * cos(x)
     f(x,y) = y == 1 ? f1(x) : (y == 2 ? f2(x) : (y == 3 ? f3(x) : error("invalid value for y (must be 1, 2 or 3, you used $y)")))
     ys = 1:3
 
@@ -15,7 +15,7 @@ using Interpolations, Test, LinearAlgebra, Random
 
     for (ix,x0) in enumerate(xs[1:end-1]), y0 in ys
         x,y = x0, y0
-        @test ≈(sitp(x,y),f(x,y),atol=0.05)
+        @test sitp(x,y) ≈ f(x,y) atol=0.05
     end
 
     @test length(Interpolations.gradient(sitp, pi/3, 2)) == 1
@@ -29,11 +29,11 @@ using Interpolations, Test, LinearAlgebra, Random
         if y in (1,2)
             @test_broken h = @inferred(Interpolations.hessian(sitp, x, y))
             h = Interpolations.hessian(sitp, x, y)
-            @test ≈(h[1], -f(x,y), atol=0.05)
+            @test h[1] ≈ -f(x, y) atol=0.05
         else # y==3
             @test_broken h = @inferred(Interpolations.hessian(sitp, x, y))
             h = Interpolations.hessian(sitp, x, y)
-            @test ≈(h[1], -4*f(x,y), atol=0.05)
+            @test h[1] ≈ -4*f(x, y) atol=0.05
         end
     end
 
@@ -46,9 +46,9 @@ using Interpolations, Test, LinearAlgebra, Random
     h(1, xs[10])
     for x in xs[6:end-6], y in ys
         if y in (1,2)
-            @test ≈(h(y,x)[1], -f(x,y), atol=0.05)
+            @test h(y, x)[1] ≈ -f(x, y) atol=0.05
         elseif y==3
-            @test ≈(h(y,x)[1], -4*f(x,y), atol=0.05)
+            @test h(y, x)[1] ≈ -4*f(x, y) atol=0.05
         end
     end
 

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -20,20 +20,18 @@ using Interpolations, Test, LinearAlgebra, Random
 
     @test length(Interpolations.gradient(sitp, pi/3, 2)) == 1
 
-    xs = range(-pi, stop=pi, length=60)
+    xs = range(-pi, stop=pi, length=60)[1:end-1]
     A = hcat(map(f1, xs), map(f2, xs), map(f3, xs))
     itp = interpolate(A, (BSpline(Cubic(Periodic(OnGrid()))), NoInterp()))
     sitp = scale(itp, xs, ys)
 
-    for x in (xs[6:end-5] .+ 0.05), y in ys
+    for x in xs, y in ys
         if y in (1,2)
-            @test_broken h = @inferred(Interpolations.hessian(sitp, x, y))
-            h = Interpolations.hessian(sitp, x, y)
-            @test h[1] ≈ -f(x, y) atol=0.05
+            h = @inferred(Interpolations.hessian(sitp, x, y))
+            @test h[1] ≈ -f(x, y) atol=0.01
         else # y==3
-            @test_broken h = @inferred(Interpolations.hessian(sitp, x, y))
-            h = Interpolations.hessian(sitp, x, y)
-            @test h[1] ≈ -4*f(x, y) atol=0.05
+            h = @inferred(Interpolations.hessian(sitp, x, y))
+            @test h[1] ≈ -4*f(x, y) atol=0.01
         end
     end
 

--- a/test/scaling/nointerp.jl
+++ b/test/scaling/nointerp.jl
@@ -24,13 +24,16 @@ using Interpolations, Test, LinearAlgebra, Random
     A = hcat(map(f1, xs), map(f2, xs), map(f3, xs))
     itp = interpolate(A, (BSpline(Cubic(Periodic(OnGrid()))), NoInterp()))
     sitp = scale(itp, xs, ys)
-    h(x, y) = Interpolations.hessian(sitp, x, y)
-    h(xs[10], 1)
-    for x in xs[6:end-6], y in ys
+
+    for x in (xs[6:end-5] .+ 0.05), y in ys
         if y in (1,2)
-            @test ≈(h(x,y)[1], -f(x,y), atol=0.05)
-        elseif y==3
-            @test ≈(h(x,y)[1], -4*f(x,y), atol=0.05)
+            @test_broken h = @inferred(Interpolations.hessian(sitp, x, y))
+            h = Interpolations.hessian(sitp, x, y)
+            @test ≈(h[1], -f(x,y), atol=0.05)
+        else # y==3
+            @test_broken h = @inferred(Interpolations.hessian(sitp, x, y))
+            h = Interpolations.hessian(sitp, x, y)
+            @test ≈(h[1], -4*f(x,y), atol=0.05)
         end
     end
 

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -1,5 +1,5 @@
 using Interpolations
-using Test, LinearAlgebra
+using Test, LinearAlgebra, StaticArrays
 
 @testset "Scaling" begin
     # Model linear interpolation of y = -3 + .5x by interpolating y=x
@@ -50,7 +50,6 @@ using Test, LinearAlgebra
     zs = sin.(xs) .* sin.(ys')
     itp = interpolate(zs, BSpline(Cubic(Line(OnGrid()))))
     sitp = @inferred scale(itp, xs, ys)
-    hitp = (x,y) -> Interpolations.hessian(sitp, x, y)
 
     for x in xs[2:end-1], y in ys[2:end-1]
         h = @inferred(Interpolations.hessian(sitp, x, y))

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -44,6 +44,20 @@ using Test, LinearAlgebra
         @test ≈(cos(x),g,atol=0.05)
     end
 
+    # Test Hessians of scaled grids
+    xs = -pi:.1:pi
+    ys = -pi:.1:pi
+    zs = sin.(xs') .* sin.(ys)
+    itp = interpolate(zs, BSpline(Cubic(Line(OnGrid()))))
+    sitp = @inferred scale(itp, xs, ys)
+    hitp = (x,y) -> Interpolations.hessian(sitp, x, y)
+
+    for x in xs[2:end-1], y in ys[2:end-1]
+        # h = @inferred(Interpolations.hessian(sitp, x, y))[1]
+        h = Interpolations.hessian(sitp, x, y)
+        @test ≈([-sin(x) * sin(y) cos(x) * cos(y); cos(x) * cos(y) -sin(x) * sin(y)], h, atol=0.03)
+    end
+
     # Verify that return types are reasonable
     @inferred(sitp2(-3.4, 1.2))
     @inferred(sitp2(-3, 1))

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -46,8 +46,8 @@ using Test, LinearAlgebra
 
     # Test Hessians of scaled grids
     xs = -pi:.1:pi
-    ys = -pi:.1:pi
-    zs = sin.(xs') .* sin.(ys)
+    ys = -pi:.2:pi
+    zs = sin.(xs) .* sin.(ys')
     itp = interpolate(zs, BSpline(Cubic(Line(OnGrid()))))
     sitp = @inferred scale(itp, xs, ys)
     hitp = (x,y) -> Interpolations.hessian(sitp, x, y)

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -53,8 +53,8 @@ using Test, LinearAlgebra
     hitp = (x,y) -> Interpolations.hessian(sitp, x, y)
 
     for x in xs[2:end-1], y in ys[2:end-1]
-        # h = @inferred(Interpolations.hessian(sitp, x, y))[1]
-        h = Interpolations.hessian(sitp, x, y)
+        h = @inferred(Interpolations.hessian(sitp, x, y))
+        @test issymmetric(h)
         @test ≈([-sin(x) * sin(y) cos(x) * cos(y); cos(x) * cos(y) -sin(x) * sin(y)], h, atol=0.03)
     end
 

--- a/test/scaling/scaling.jl
+++ b/test/scaling/scaling.jl
@@ -41,7 +41,7 @@ using Test, LinearAlgebra, StaticArrays
 
     for x in -pi:.1:pi
         g = @inferred(Interpolations.gradient(sitp, x))[1]
-        @test ≈(cos(x),g,atol=0.05)
+        @test cos(x) ≈ g atol=0.05
     end
 
     # Test Hessians of scaled grids
@@ -54,7 +54,8 @@ using Test, LinearAlgebra, StaticArrays
     for x in xs[2:end-1], y in ys[2:end-1]
         h = @inferred(Interpolations.hessian(sitp, x, y))
         @test issymmetric(h)
-        @test ≈([-sin(x) * sin(y) cos(x) * cos(y); cos(x) * cos(y) -sin(x) * sin(y)], h, atol=0.03)
+        @test [-sin(x) * sin(y) cos(x) * cos(y)
+                cos(x) * cos(y) -sin(x) * sin(y)] ≈ h atol=0.03
     end
 
     # Verify that return types are reasonable


### PR DESCRIPTION
This adds `hessian` functionality to `ScaledInterpolation`s. The inference issue seems to be due to `symmatrix`, as far as I can tell, but inference hasn't been tested on `hessian` for `BSplineInterpolation` either, so that may not be too bad.

The current implementation avoids unnecessary (by symmetry) rescaling operations and allocation of arrays (as would have been necessary in any recursive implementation I could come up with).

EDIT: (sort of) fixes #268.