### PR TITLE
Fix inference for certain hessian BC/NoInterp combinations

### DIFF
--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -125,11 +125,12 @@ end
 slot_substitute(kind1::Tuple{Int,Vararg{Any}}, kind2, p, v, g, h) = slot_substitute(Base.tail(kind1), kind2, p, v, g, h)
 # Substitute the dth dimension's gradient coefs for the remaining coefs
 function slot_substitute(kind1::K, kind2::K, p, v, g, h) where K
-    (maybe_weightedindex.(p, substitute_ruled(v, kind1, h)), slot_substitute(Base.tail(kind1), kind2, p, v, g, h)...)
+    ss = substitute_ruled(v, kind1, h)
+    (map(maybe_weightedindex, p, ss), slot_substitute(Base.tail(kind1), kind2, p, v, g, h)...)
 end
 function slot_substitute(kind1, kind2, p, v, g, h)
     ss = substitute_ruled(substitute_ruled(v, kind1, g), kind2, g)
-    (maybe_weightedindex.(p, ss), slot_substitute(Base.tail(kind1), kind2, p, v, g, h)...)
+    (map(maybe_weightedindex, p, ss), slot_substitute(Base.tail(kind1), kind2, p, v, g, h)...)
 end
 # Termination
 slot_substitute(kind1::Tuple{}, kind2::Tuple{Int,Vararg{Any}}, p, v, g, h) = _slot_substitute(kind1::Tuple{}, kind2, p, v, g, h)

--- a/test/hessian.jl
+++ b/test/hessian.jl
@@ -15,13 +15,11 @@ using Test, Interpolations, LinearAlgebra, ForwardDiff
             if ndims(A) == 1
                 # Hessian of Constant and Linear should always be 0 in 1d
                 for x in InterpolationTestUtils.thirds(axes(A))
-                    @test all(iszero, Interpolations.hessian(itp, x...))
-                    @test all(iszero, Interpolations.hessian!(h, itp, x...))
+                    @test all(iszero, @inferred(Interpolations.hessian(itp, x...)))
+                    @test all(iszero, @inferred(Interpolations.hessian!(h, itp, x...)))
                 end
             else
-                for x in InterpolationTestUtils.thirds(axes(A))
-                    check_hessian(itp, h)
-                end
+                check_hessian(itp, h)
             end
         end
 
@@ -41,8 +39,11 @@ using Test, Interpolations, LinearAlgebra, ForwardDiff
     itp = interpolate(A2, (BSpline(Quadratic(Flat(OnCell()))), NoInterp()))
     v = A2[:, 2]
     itpcol = interpolate(v, BSpline(Quadratic(Flat(OnCell()))))
-    @test Interpolations.hessian(itp, 3.2, 2) == Interpolations.hessian(itpcol, 3.2)
+    @test @inferred(Interpolations.hessian(itp, 3.2, 2)) == @inferred(Interpolations.hessian(itpcol, 3.2))
 
+    itp = interpolate(A2, (BSpline(Quadratic(Periodic(OnGrid()))), NoInterp()))
+    itpcol = interpolate(v, BSpline(Quadratic(Periodic(OnGrid()))))
+    @test @inferred(Interpolations.hessian(itp, 1.0, 2)) == @inferred(Interpolations.hessian(itpcol, 1.0))
 
     @testset "Monotonic" begin
         x = [0.0, 0.2, 0.5, 0.6, 0.9, 1.0]


### PR DESCRIPTION
It's a little unclear why switching from broadcasting to `map` works, but in any case it's easier on the compiler which is a good thing in and of itself.

@dkarrasch, once this merges you can rebase your branch on master, and I think it should fix the inference problem.