### PR TITLE
Add convenience utilities for working with WeightedIndex

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -212,12 +212,20 @@ WeightedIndex(indexes::NTuple{L,Integer}, weights::NTuple{L,Any}) where L =
 weights(wi::WeightedIndex) = wi.weights
 indexes(wi::WeightedAdjIndex) = wi.istart
 indexes(wi::WeightedArbIndex) = wi.indexes
+indextuple(wi::WeightedAdjIndex{L}) where L = ntuple(i->wi.istart+i-1, Val(L))
+indextuple(wi::WeightedArbIndex{L}) where L = indexes(wi)
 
 # Make them iterable just like numbers are
 Base.iterate(x::WeightedIndex) = (x, nothing)
 Base.iterate(x::WeightedIndex, ::Any) = nothing
 Base.isempty(x::WeightedIndex) = false
 Base.length(x::WeightedIndex) = 1
+
+# Supporting arithmetic on the weights allows one to perform pre-scaling of gradient coefficients
+Base.:(*)(wi::WeightedAdjIndex, x::Number) = WeightedAdjIndex(wi.istart, wi.weights .* x)
+Base.:(/)(wi::WeightedAdjIndex, x::Number) = WeightedAdjIndex(wi.istart, wi.weights ./ x)
+Base.:(*)(wi::WeightedArbIndex, x::Number) = WeightedArbIndex(wi.indexes, wi.weights .* x)
+Base.:(/)(wi::WeightedArbIndex, x::Number) = WeightedArbIndex(wi.indexes, wi.weights ./ x)
 
 ### Indexing with WeightedIndex
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,3 +1,5 @@
+using Interpolations, Test
+
 @testset "Core" begin
     A = reshape([0], 1, 1, 1, 1, 1)
     wis = ntuple(d->Interpolations.WeightedAdjIndex(1, (1,)), ndims(A))
@@ -12,4 +14,13 @@
     @test @inferred(A[wis...]) === 0
     wis = ntuple(d->Interpolations.WeightedArbIndex((1,1), (1.0,0.0)), ndims(A))
     @test @inferred(A[wis...]) === 0.0
+
+    wi = Interpolations.WeightedAdjIndex(2, (0.2, 0.8))
+    @test wi*2 === Interpolations.WeightedAdjIndex(2, (0.4, 1.6))
+    @test wi/2 === Interpolations.WeightedAdjIndex(2, (0.1, 0.4))
+    @test Interpolations.indextuple(wi) == (2, 3)
+    wi = Interpolations.WeightedArbIndex((2, -1), (0.2, 0.8))
+    @test wi*2 === Interpolations.WeightedArbIndex((2, -1), (0.4, 1.6))
+    @test wi/2 === Interpolations.WeightedArbIndex((2, -1), (0.1, 0.4))
+    @test Interpolations.indextuple(wi) == (2, -1)
 end


### PR DESCRIPTION
WeightedIndex is now the central concept in Interpolations; it makes sense to have a few more convenience utilities. In particular the arithmetic operations are aimed at rescaling, and might someday be useful for an `eachgradient` analogous to `eachvalue`.