### PR TITLE
Require that singleton dimensions be NoInterp. Fixes #289.

### DIFF
--- a/test/b-splines/linear.jl
+++ b/test/b-splines/linear.jl
@@ -52,4 +52,13 @@
     itp = interpolate(x, BSpline(Linear()))
     @test itp(1.5, CartesianIndex((2, 3))) === itp(1.5, 2, 3)
     @test itp(CartesianIndex((1, 2)), 1.5) === itp(1, 2, 1.5)
+
+    # Issue #289
+    for (x, it) in ((ones(1, 3), (NoInterp(), BSpline(Linear()))),
+                    (ones(3, 1), (BSpline(Linear()), NoInterp())))
+        @test_throws ArgumentError interpolate(x, BSpline(Linear()))
+        itp = interpolate(x, it)
+        etp = extrapolate(itp, Flat())
+        @test sum(isnan.(etp)) == 0
+    end
 end

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -85,7 +85,6 @@ using Interpolations, Test, ForwardDiff
         println(io, GradientWrapper(eff, p, test))
         println(io, "Done.")
         str = String(take!(io))
-        @show str
         @test endswith(str, "Done.\n")
     end
 


### PR DESCRIPTION
CC @zygmuntszpak. I wonder if this could be breaking, so I'll leave it open a while for comment.