### PR TITLE
 add fft-based interpolation for 1D real signals

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -21,6 +21,7 @@ export
     InPlace,
     InPlaceQ,
     Throw,
+    FFT,
 
     LinearInterpolation,
     CubicSplineInterpolation
@@ -433,5 +434,6 @@ include("utils.jl")
 include("io.jl")
 include("convenience-constructors.jl")
 include("deprecations.jl")
+include("fftbased/with_ffts.jl")
 
 end # module

--- a/src/fftbased/with_ffts.jl
+++ b/src/fftbased/with_ffts.jl
@@ -1,0 +1,12 @@
+import FFTW: irfft,rfft
+
+struct FFT <: InterpolationType
+    new_size::Number
+end
+
+function interpolate(sig::AbstractArray{<:Real,1},it::FFT)
+    ## For real signal, so we can used the real fast fourier transform (rfft) to interpolate the signal
+    length(sig) >= it.new_size && error("New size of signal must be superior or equal")
+    n_orig = div(length(sig),2)
+    return irfft( vcat(rfft(sig),zeros( div(it.new_size,2 ) - n_orig )  ), it.new_size)
+end


### PR DESCRIPTION
Simple test that I didn't included yet 

``` 
using Interpolations
N=512
new_size = 1024

sig = sin.( 2 * pi * 0.01 * N .* range(0,1,length=N) )
new_sig = interpolate(sig,FFT(new_size))
sig2 = sin.( 2 * pi * 0.01 * N .* range(0,1,length=new_size) )
```
You can check using Plots that `sig2` and `new_sig` have the same frequency