### PR TITLE
A few performance improvements. Fixes #311

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -416,11 +416,11 @@ checklubounds(ls, us, xs) = _checklubounds(true, ls, us, xs)
 _checklubounds(tf::Bool, ls, us, xs::Tuple{Number, Vararg{Any}}) =
     _checklubounds(tf & (ls[1] <= xs[1] <= us[1]), Base.tail(ls), Base.tail(us), Base.tail(xs))
 _checklubounds(tf::Bool, ls, us, xs::Tuple{AbstractVector, Vararg{Any}}) =
-    _checklubounds(tf & all(ls[1] .<= xs[1] .<= us[1]), Base.tail(ls), Base.tail(us), Base.tail(xs))
+    _checklubounds(tf & allbetween(ls[1], xs[1], us[1]), Base.tail(ls), Base.tail(us), Base.tail(xs))
 _checklubounds(tf::Bool, ::Tuple{}, ::Tuple{}, ::Tuple{}) = tf
 
 maybe_clamp(itp, xs) = maybe_clamp(BoundsCheckStyle(itp), itp, xs)
-maybe_clamp(::NeedsCheck, itp, xs) = clamp.(xs, lbounds(itp), ubounds(itp))
+maybe_clamp(::NeedsCheck, itp, xs) = map(clamp, xs, lbounds(itp), ubounds(itp))
 maybe_clamp(::CheckWillPass, itp, xs) = xs
 
 include("nointerp/nointerp.jl")

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -25,8 +25,10 @@ end
 @propagate_inbounds function gradient(itp::BSplineInterpolation{T,N}, x::Vararg{Number,N}) where {T,N}
     @boundscheck checkbounds(Bool, itp, x...) || Base.throw_boundserror(itp, x)
     wis = weightedindexes((value_weights, gradient_weights), itpinfo(itp)..., x)
-    SVector(map(inds->itp.coefs[inds...], wis))
+    return _gradient(itp.coefs, wis)   # work around #311
 end
+@noinline _gradient(coefs, wis) = SVector(map(inds->coefs[inds...], wis))
+
 @propagate_inbounds function gradient!(dest, itp::BSplineInterpolation{T,N}, x::Vararg{Number,N}) where {T,N}
     dest .= gradient(itp, x...)
 end

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -41,8 +41,10 @@ count_interp_dims(::Type{<:Extrapolation{T,N,ITPT}}, n) where {T,N,ITPT} = count
     itp = parent(etp)
     eflag = etpflag(etp)
     xs = inbounds_position(eflag, bounds(itp), x, etp, x)
+    itpval = @inbounds(itp(xs...))
+    ((xs == x) & allisreal(x)) && return itpval
     g = @inbounds gradient(itp, xs...)
-    extrapolate_value(eflag, skip_flagged_nointerp(itp, x), skip_flagged_nointerp(itp, xs), Tuple(g), @inbounds(itp(xs...)))
+    extrapolate_value(eflag, skip_flagged_nointerp(itp, x), skip_flagged_nointerp(itp, xs), Tuple(g), itpval)
 end
 @inline function (etp::Extrapolation{T,N})(x::Vararg{Union{Number,AbstractVector},N}) where {T,N}
     itp = parent(etp)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -97,3 +97,12 @@ function getindex!(dest, itp, xs...)
     end
     return dest
 end
+
+function allbetween(l::Real, xs, u::Real)
+    ret = true
+    @inbounds for x in xs
+        ret = ret & (l <= x) & (x <= u)
+    end
+    return ret
+end
+allbetween(l::Real, xs::AbstractRange, u::Real) = (l <= minimum(xs)) & (maximum(xs) <= u)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -106,3 +106,8 @@ function allbetween(l::Real, xs, u::Real)
     return ret
 end
 allbetween(l::Real, xs::AbstractRange, u::Real) = (l <= minimum(xs)) & (maximum(xs) <= u)
+
+allisreal(x) = _allisreal(true, x...)
+@inline _allisreal(ret, x1::Real, xs...) = _allisreal(ret, xs...)
+@inline _allisreal(ret, x1, xs...) = _allisreal(false, xs...)
+_allisreal(ret) = ret


### PR DESCRIPTION
See #311, https://discourse.julialang.org/t/using-interpolations/23933, and https://discourse.julialang.org/t/help-with-poor-linearinterpolation-performance/22325.

There is still some ways to go, particularly for `Gridded` (Julia's `searchsortedfirst` is not speedy), but this helps.
