### PR TITLE
Use the abstract type AbstractUnitRange instead of UnitRange in coordlookup

### DIFF
--- a/src/scaling/scaling.jl
+++ b/src/scaling/scaling.jl
@@ -94,7 +94,7 @@ coordslookup(::Any, ::Tuple{}, ::Tuple{}) = ()
 coordlookup(::NoInterp, r, i) = i
 coordlookup(::Flag, r, x) = coordlookup(r, x)
 
-coordlookup(r::UnitRange, x) = x - r.start + oneunit(eltype(r))
+coordlookup(r::AbstractUnitRange, x) = x - first(r) + oneunit(eltype(r))
 # coordlookup(i::Bool, r::AbstractRange, x) = i ? coordlookup(r, x) : convert(typeof(coordlookup(r,x)), x)
 coordlookup(r::StepRange, x) = (x - r.start) / r.step + oneunit(eltype(r))
 


### PR DESCRIPTION
This will allow us to use indices of Arrays as the x-coordinate in interpolations, eg. in LinearInterpolation. The value obtained from axes(arr,1) would be of type Base.OneTo, which is a subtype of AbstractUnitRange.