### PR TITLE
reduced allocations in getindex!

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,7 +91,7 @@ function _inbounds((l,u)::Tuple{Number,Number}, x::AbstractVector)
     ret
 end
 
-function getindex!(dest, itp, xs...)
+function getindex!(dest, itp, xs::Vararg{AbstractArray,N}) where N
     for (i, x) in zip(eachindex(dest), Iterators.product(xs...))
         dest[i] = itp(x...)
     end


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/issues/32761 two versions of a similar `getindex!` functions are compared. It seems to be a problem with splatting of an unknown sized object. It helps when the size is a parameter. 
Tests ran through on my computer.
This addresses the allocations seen in #331. Timing also got a bit better

```julia
using BenchmarkTools
using Interpolations

itp = interpolate((LinRange(0,1,10), LinRange(0,1,10)), rand(10,10), Gridded(Constant()))

@btime itp(rand(10),rand(10)) # 1.577 μs (14 allocations: 2.16 KiB)
@btime itp(rand(100),rand(100)) # 23.560 μs (15 allocations: 85.42 KiB)

etp = extrapolate(itp,0.0)
#before 
@btime etp(rand(10),rand(10)) # 71.440 μs (1228 allocations: 44.77 KiB)
@btime etp(rand(100),rand(100)) # 6.828 ms (120035 allocations: 4.20 MiB)
#after 
@btime etp(rand(10),rand(10)) #  8.483 μs (23 allocations: 2.45 KiB)
@btime etp(rand(100),rand(100)) # 795.646 μs (30 allocations: 86.38 KiB)
```


