### PR TITLE
Fixed printing of monotonic interpolation objects

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -107,16 +107,19 @@ function show_ranged(io::IO, X, knots)
     Base.print_array(io, [X(x...) for x in Iterators.product(knots...)])
 end
 
-getknots(X::BSplineInterpolation)  = axes(X)
-getknots(X::ScaledInterpolation)   = X.ranges
-getknots(X::GriddedInterpolation)  = X.knots
-getknots(X::AbstractExtrapolation) = getknots(parent(X))
+getknots(X::BSplineInterpolation)   = axes(X)
+getknots(X::ScaledInterpolation)    = X.ranges
+getknots(X::GriddedInterpolation)   = X.knots
+getknots(X::AbstractExtrapolation)  = getknots(parent(X))
+getknots(X::MonotonicInterpolation) = (X.knots,)
 
-Base.show(io::IO, ::MIME{Symbol("text/plain")}, X::ScaledInterpolation)   = show_ranged(io, X, getknots(X))
-Base.show(io::IO, ::MIME{Symbol("text/plain")}, X::GriddedInterpolation)  = show_ranged(io, X, getknots(X))
-Base.show(io::IO, ::MIME{Symbol("text/plain")}, X::AbstractExtrapolation) = show_ranged(io, X, getknots(X))
+Base.show(io::IO, ::MIME{Symbol("text/plain")}, X::ScaledInterpolation)    = show_ranged(io, X, getknots(X))
+Base.show(io::IO, ::MIME{Symbol("text/plain")}, X::GriddedInterpolation)   = show_ranged(io, X, getknots(X))
+Base.show(io::IO, ::MIME{Symbol("text/plain")}, X::AbstractExtrapolation)  = show_ranged(io, X, getknots(X))
+Base.show(io::IO, ::MIME{Symbol("text/plain")}, X::MonotonicInterpolation) = show_ranged(io, X, getknots(X))
 
 # these are called by show(X)
-Base.show(io::IO, X::ScaledInterpolation)   = show_ranged(io, X, getknots(X))
-Base.show(io::IO, X::GriddedInterpolation)  = show_ranged(io, X, getknots(X))
-Base.show(io::IO, X::AbstractExtrapolation) = show_ranged(io, X, getknots(X))
+Base.show(io::IO, X::ScaledInterpolation)    = show_ranged(io, X, getknots(X))
+Base.show(io::IO, X::GriddedInterpolation)   = show_ranged(io, X, getknots(X))
+Base.show(io::IO, X::AbstractExtrapolation)  = show_ranged(io, X, getknots(X))
+Base.show(io::IO, X::MonotonicInterpolation) = show_ranged(io, X, getknots(X))

--- a/test/io.jl
+++ b/test/io.jl
@@ -85,10 +85,21 @@ using Test
     end
 
     @testset "Monotonic" begin
-        A = rand(20)
         A_x = collect(1.0:2.0:40.0)
+        A = map(x->x^2, A_x)
         itp = interpolate(A_x, A, FritschButlandMonotonicInterpolation())
-        @test summary(itp) == "20-element interpolate(::Array{Float64,1}, ::Array{Float64,1}, FritschButlandMonotonicInterpolation()) with element type Float64"
+        teststring = "20-element interpolate(::Array{Float64,1}, ::Array{Float64,1}, FritschButlandMonotonicInterpolation()) with element type Float64"
+        @test summary(itp) == teststring
+
+        io = IOBuffer()
+        show(io, itp)
+        str = String(take!(io))
+        @test occursin(teststring, str)
+
+        io2 = IOBuffer()
+        show(io2, MIME("text/plain"), itp)
+        str = String(take!(io2))
+        @test occursin(teststring, str)
     end
 
     @testset "Extrapolation" begin


### PR DESCRIPTION
I've fixed printing of monotonic interpolation objects. If they are wrapped in an extrapolation object, printing them on the master branch even causes an error.