### PR TITLE
Performance improvements in gradient computation

### DIFF
--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -25,9 +25,10 @@ end
 @propagate_inbounds function gradient(itp::BSplineInterpolation{T,N}, x::Vararg{Number,N}) where {T,N}
     @boundscheck checkbounds(Bool, itp, x...) || Base.throw_boundserror(itp, x)
     wis = weightedindexes((value_weights, gradient_weights), itpinfo(itp)..., x)
-    return _gradient(itp.coefs, wis)   # work around #311
+    return SVector(_gradient(itp.coefs, wis...))   # work around #311
 end
-@noinline _gradient(coefs, wis) = SVector(map(inds->coefs[inds...], wis))
+@inline _gradient(coefs, inds, moreinds...) = (coefs[inds...], _gradient(coefs, moreinds...)...)
+_gradient(coefs) = ()
 
 @propagate_inbounds function gradient!(dest, itp::BSplineInterpolation{T,N}, x::Vararg{Number,N}) where {T,N}
     dest .= gradient(itp, x...)


### PR DESCRIPTION
From the benchmarks in #311, this is a further improvement compared to #315:
```julia
julia> @time interp_test1(500)
  8.222822 seconds (10 allocations: 2.794 GiB, 1.44% gc time)
-5168.12456559581

julia> @time interp_test2(500)
  5.556805 seconds (10 allocations: 2.794 GiB, 2.03% gc time)
-1605.1519426096165

julia> @time interp_test3(500)
  6.571917 seconds (11 allocations: 2.788 GiB, 1.69% gc time)
-6341.612041378765

julia> @time interp_test4(500)
  4.652481 seconds (9 allocations: 2.788 GiB, 2.53% gc time)
-24121.63637598708
```
The large number of allocations has been eliminated.