### PR TITLE
Add support for Unitful.jl numbers to FilledExtrapolations

### DIFF
--- a/perf/benchmarks.jl
+++ b/perf/benchmarks.jl
@@ -30,14 +30,14 @@ end
 strip_prefix(str::AbstractString) = replace(str, "Interpolations."=>"")
 benchstr(::Type{T}) where {T<:Interpolations.GridType} = strip_prefix(string(T))
 
-benchstr(::Type{Constant}) = "Constant()"
+benchstr(::Type{<:Constant}) = "Constant()"
 benchstr(::Type{Linear}) = "Linear()"
 benchstr(::Type{Quadratic{BC}}, ::Type{GT}) where {BC<:Interpolations.BoundaryCondition,GT<:Interpolations.GridType} =
     string("Quadratic(", strip_prefix(string(BC)), "(", strip_prefix(string(GT)), "()))")
 benchstr(::Type{Cubic{BC}}, ::Type{GT}) where {BC<:Interpolations.BoundaryCondition,GT<:Interpolations.GridType} =
     string("Cubic(", strip_prefix(string(BC)), "(", strip_prefix(string(GT)), "()))")
 
-groupstr(::Type{Constant}) = "constant"
+groupstr(::Type{<:Constant}) = "constant"
 groupstr(::Type{Linear}) = "linear"
 groupstr(::Type{Quadratic}) = "quadratic"
 groupstr(::Type{Cubic}) = "cubic"

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -161,6 +161,11 @@ function interpolate(::Type{TWeights}, ::Type{TC}, A, it::IT) where {TWeights,TC
     BSplineInterpolation(TWeights, Apad, it, axes(A))
 end
 
+function interpolate(::Type{TWeights}, ::Type{TC}, A, it::IT, λ::Real, k::Int) where {TWeights,TC,IT<:DimSpec{BSpline}}
+    Apad = prefilter(TWeights, TC, A, it, λ, k)
+    BSplineInterpolation(TWeights, Apad, it, axes(A))
+end
+
 """
     itp = interpolate(A, interpmode)
 
@@ -177,6 +182,33 @@ It may also be a tuple of such values, if you want to use different interpolatio
 """
 function interpolate(A::AbstractArray, it::IT) where {IT<:DimSpec{BSpline}}
     interpolate(tweight(A), tcoef(A), A, it)
+end
+
+"""
+    itp = interpolate(A, interpmode, gridstyle, λ, k)
+
+Interpolate an array `A` in the mode determined by `interpmode` and `gridstyle`
+with regularization following [1], of order `k` and constant `λ`. 
+`interpmode` may be one of
+
+- `BSpline(NoInterp())`
+- `BSpline(Linear())`
+- `BSpline(Quadratic(BC()))` (see [`BoundaryCondition`](@ref))
+- `BSpline(Cubic(BC()))`
+
+It may also be a tuple of such values, if you want to use different interpolation schemes along each axis.
+
+`gridstyle` should be one of `OnGrid()` or `OnCell()`.
+
+`k` corresponds to the derivative to penalize. In the limit λ->∞, the interpolation function is
+a polynomial of order `k-1`. A value of 2 is the most common.
+
+`λ` is non-negative. If its value is zero, it falls back to non-regularized interpolation.
+
+[1] https://projecteuclid.org/euclid.ss/1038425655.
+"""
+function interpolate(A::AbstractArray, it::IT, λ::Real, k::Int) where {IT<:DimSpec{BSpline}}
+    interpolate(tweight(A), tcoef(A), A, it, λ, k)
 end
 
 # We can't just return a tuple-of-types due to julia #12500
@@ -198,6 +230,16 @@ function interpolate!(::Type{TWeights}, A::AbstractArray, it::IT) where {TWeight
 end
 function interpolate!(A::AbstractArray, it::IT) where {IT<:DimSpec{BSpline}}
     interpolate!(tweight(A), A, it)
+end
+
+function interpolate!(::Type{TWeights}, A::AbstractArray, it::IT, λ::Real, k::Int) where {TWeights,IT<:DimSpec{BSpline}}
+    # Set the bounds of the interpolant inward, if necessary
+    axsA = axes(A)
+    axspad = padded_axes(axsA, it)
+    BSplineInterpolation(TWeights, prefilter!(TWeights, A, it, λ, k), it, fix_axis.(padinset.(axsA, axspad)))
+end
+function interpolate!(A::AbstractArray, it::IT, λ::Real, k::Int) where {IT<:DimSpec{BSpline}}
+    interpolate!(tweight(A), A, it, λ, k)
 end
 
 lut!(dl, d, du) = lu!(Tridiagonal(dl, d, du), Val(false))

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -252,6 +252,6 @@ include("indexing.jl")
 include("prefiltering.jl")
 include("../filter1d.jl")
 
-Base.parent(A::BSplineInterpolation{T,N,TCoefs,UT}) where {T,N,TCoefs,UT<:Union{BSpline{Linear},BSpline{Constant}}} = A.coefs
+Base.parent(A::BSplineInterpolation{T,N,TCoefs,UT}) where {T,N,TCoefs,UT<:Union{BSpline{Linear},BSpline{<:Constant}}} = A.coefs
 Base.parent(A::BSplineInterpolation{T,N,TCoefs,UT}) where {T,N,TCoefs,UT} =
     throw(ArgumentError("The given BSplineInterpolation does not serve as a \"view\" for a parent array. This would only be true for Constant and Linear b-splines."))

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -1,4 +1,15 @@
-struct Constant <: Degree{0} end
+export Nearest, Previous, Next
+
+abstract type ConstantInterpType end
+struct Nearest <: ConstantInterpType end
+struct Previous <: ConstantInterpType end
+struct Next <: ConstantInterpType end
+
+struct Constant{T<:ConstantInterpType} <: Degree{0}
+    Constant() = new{Nearest}()
+    Constant{Previous}() = new{Previous}()
+    Constant{Next}() = new{Next}()
+end
 
 """
 Constant b-splines are *nearest-neighbor* interpolations, and effectively
@@ -6,7 +17,17 @@ return `A[round(Int,x)]` when interpolating.
 """
 Constant
 
-function positions(::Constant, ax, x)  # discontinuity occurs at half-integer locations
+function positions(c::Constant{Previous}, ax, x)  # discontinuity occurs at integer locations
+    xm = floorbounds(x, ax)
+    δx = x - xm
+    fast_trunc(Int, xm), δx
+end
+function positions(c::Constant{Next}, ax, x)  # discontinuity occurs at integer locations
+    xm = ceilbounds(x, ax)
+    δx = x - xm
+    fast_trunc(Int, xm), δx
+end
+function positions(c::Constant{Nearest}, ax, x)  # discontinuity occurs at half-integer locations
     xm = roundbounds(x, ax)
     δx = x - xm
     fast_trunc(Int, xm), δx
@@ -16,4 +37,4 @@ value_weights(::Constant, δx) = (1,)
 gradient_weights(::Constant, δx) = (0,)
 hessian_weights(::Constant, δx) = (0,)
 
-padded_axis(ax::AbstractUnitRange, ::BSpline{Constant}) = ax
+padded_axis(ax::AbstractUnitRange, ::BSpline{<:Constant}) = ax

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -199,6 +199,16 @@ function _floorbounds(x, ax::Union{Tuple{Real,Real}, AbstractUnitRange})
     ifelse(x < l, floor(x+h), floor(x+zero(h)))
 end
 
+ceilbounds(x::Integer, ax::Tuple{Real,Real}) = x
+ceilbounds(x::Integer, ax::AbstractUnitRange) = x
+ceilbounds(x, ax::Tuple{Real,Real}) = _ceilbounds(x, ax)
+ceilbounds(x, ax::AbstractUnitRange) = _ceilbounds(x, ax)
+function _ceilbounds(x, ax::Union{Tuple{Real,Real}, AbstractUnitRange})
+    u = last(ax)
+    h = half(x)
+    ifelse(x > u, ceil(x+h), ceil(x+zero(h)))
+end
+
 half(x) = oneunit(x)/2
 
 symmatrix(h::NTuple{1,Any}) = SMatrix{1,1}(h)

--- a/src/extrapolation/filled.jl
+++ b/src/extrapolation/filled.jl
@@ -30,7 +30,7 @@ extrapolate(itp::AbstractInterpolation{T,N,IT}, fillvalue) where {T,N,IT} = Fill
 @inline function (etp::FilledExtrapolation{T,N})(x::Vararg{Number,N}) where {T,N}
     itp = parent(etp)
     coefs = coefficients(itp)
-    Tret = promote_type(eltype(coefs), typeof.(x)...,T)
+    Tret = promote_type(eltype(coefs), typeof.(x)...)
     if checkbounds(Bool, itp, x...)
         @inbounds itp(x...)
     else

--- a/src/extrapolation/filled.jl
+++ b/src/extrapolation/filled.jl
@@ -30,7 +30,7 @@ extrapolate(itp::AbstractInterpolation{T,N,IT}, fillvalue) where {T,N,IT} = Fill
 @inline function (etp::FilledExtrapolation{T,N})(x::Vararg{Number,N}) where {T,N}
     itp = parent(etp)
     coefs = coefficients(itp)
-    Tret = typeof(prod(x) * zero(eltype(coefs)))
+    Tret = promote_type(eltype(coefs), typeof.(x)...,T)
     if checkbounds(Bool, itp, x...)
         @inbounds itp(x...)
     else

--- a/src/gridded/indexing.jl
+++ b/src/gridded/indexing.jl
@@ -40,6 +40,14 @@ function gridded_floorbounds(x, knotvec::AbstractVector)
     max(i, first(axes1(knotvec)))
 end
 
+ceilbounds(x::Integer, knotvec::AbstractVector) = gridded_ceilbounds(x, knotvec)
+ceilbounds(x, knotvec::AbstractVector) = gridded_ceilbounds(x, knotvec)
+function gridded_ceilbounds(x, knotvec::AbstractVector)
+    i = find_knot_index(knotvec, x)
+    iclamp = max(i, first(axes1(knotvec)))
+    min(iclamp+1, last(axes1(knotvec)))
+end
+
 @inline find_knot_index(knotv, x) = searchsortedfirst(knotv, x, Base.Order.ForwardOrdering()) - 1
 @inline find_knot_index(knotv, x::AbstractVector) = searchsortedfirst_vec(knotv, x) .- 1
 

--- a/test/b-splines/constant.jl
+++ b/test/b-splines/constant.jl
@@ -5,35 +5,108 @@
     A2 = rand(Float64, N1, N1) * 100
     A3 = rand(Float64, N1, N1, N1) * 100
 
-    for (constructor, copier) in ((interpolate, x->x), (interpolate!, copy))
-        isinplace = constructor == interpolate!
-        itp1 = @inferred(constructor(copier(A1), BSpline(Constant())))
-        itp2 = @inferred(constructor(copier(A2), BSpline(Constant())))
-        itp3 = @inferred(constructor(copier(A3), BSpline(Constant())))
+    @testset "Constant{Nearest}" begin
+        for (constructor, copier) in ((interpolate, x -> x), (interpolate!, copy))
+            isinplace = constructor == interpolate!
+            itp1 = @inferred(constructor(copier(A1), BSpline(Constant())))
+            itp2 = @inferred(constructor(copier(A2), BSpline(Constant())))
+            itp3 = @inferred(constructor(copier(A3), BSpline(Constant())))
 
-        @test parent(itp1) === itp1.coefs
-        @test Interpolations.lbounds(itp1) == (1,)
-        @test Interpolations.ubounds(itp1) == (N1,)
+            @test parent(itp1) === itp1.coefs
+            @test Interpolations.lbounds(itp1) == (1,)
+            @test Interpolations.ubounds(itp1) == (N1,)
 
-        # Evaluation on provided data points
-        for (itp, A) in ((itp1, A1), (itp2, A2), (itp3, A3))
-            check_axes(itp, A, isinplace)
-            check_inbounds_values(itp, A)
-            check_oob(itp)
-            can_eval_near_boundaries(itp)
-        end
+            # Evaluation on provided data points
+            for (itp, A) in ((itp1, A1), (itp2, A2), (itp3, A3))
+                check_axes(itp, A, isinplace)
+                check_inbounds_values(itp, A)
+                check_oob(itp)
+                can_eval_near_boundaries(itp)
+            end
 
-        # Evaluation between data points (tests constancy)
-        for i in 2:N1-1
-            @test A1[i] == itp1(i+.3) == itp1(i+.3) == itp1(i-.3) == itp1(i-.3)
+            # Evaluation between data points (tests constancy)
+            for i in 2:N1 - 1
+                @test A1[i] == itp1(i + .3) == itp1(i - .3)
+            end
+            # 2D
+            for i in 2:N1 - 1, j in 2:N1 - 1
+                @test A2[i,j] == itp2(i + .4, j - .3) == itp2(i - .4, j + .3)
+            end
+            # 3D
+            for i in 2:N1 - 1, j in 2:N1 - 1, k in 2:N1 - 1
+                @test A3[i,j,k] == itp3(i + .4, j - .3, k + .1) == itp3(i + .4, j - .3, k + .2)
+            end
         end
-        # 2D
-        for i in 2:N1-1, j in 2:N1-1
-            @test A2[i,j] == itp2(i+.4,j-.3) == itp2(i+.4,j-.3)
+    end
+
+    @testset "Constant{Previous}" begin
+        for (constructor, copier) in ((interpolate, x -> x), (interpolate!, copy))
+            isinplace = constructor == interpolate!
+            itp1 = @inferred(constructor(copier(A1), BSpline(Constant{Previous}())))
+            itp2 = @inferred(constructor(copier(A2), BSpline(Constant{Previous}())))
+            itp3 = @inferred(constructor(copier(A3), BSpline(Constant{Previous}())))
+
+            @test parent(itp1) === itp1.coefs
+            @test Interpolations.lbounds(itp1) == (1,)
+            @test Interpolations.ubounds(itp1) == (N1,)
+
+            # Evaluation on provided data points
+            for (itp, A) in ((itp1, A1), (itp2, A2), (itp3, A3))
+                check_axes(itp, A, isinplace)
+                check_inbounds_values(itp, A)
+                check_oob(itp)
+                can_eval_near_boundaries(itp)
+            end
+
+            # Evaluation between data points (tests constancy)
+            for i in 2:N1 - 1
+                @test A1[i] == itp1(i + .3) == itp1(i + .6) 
+                @test A1[i - 1] == itp1(i - .3) == itp1(i - .6)
+            end
+            # 2D
+            for i in 2:N1 - 1, j in 2:N1 - 1
+                @test A2[i,j - 1] == itp2(i + .4, j - .3) == itp2(i + .4, j - .6)
+            end
+            # 3D
+            for i in 2:N1 - 1, j in 2:N1 - 1, k in 2:N1 - 1
+                @test A3[i,j - 1,k] == itp3(i + .4, j - .3, k + .1) == itp3(i + .4, j - .3, k + .2)
+            end
         end
-        # 3D
-        for i in 2:N1-1, j in 2:N1-1, k in 2:N1-1
-            @test A3[i,j,k] == itp3(i+.4,j-.3,k+.1) == itp3(i+.4,j-.3,k+.2)
+    end
+
+    @testset "Constant{Next}" begin
+        for (constructor, copier) in ((interpolate, x -> x), (interpolate!, copy))
+            isinplace = constructor == interpolate!
+            itp1 = @inferred(constructor(copier(A1), BSpline(Constant{Next}())))
+            itp2 = @inferred(constructor(copier(A2), BSpline(Constant{Next}())))
+            itp3 = @inferred(constructor(copier(A3), BSpline(Constant{Next}())))
+
+            @test parent(itp1) === itp1.coefs
+            @test Interpolations.lbounds(itp1) == (1,)
+            @test Interpolations.ubounds(itp1) == (N1,)
+
+            # Evaluation on provided data points
+            for (itp, A) in ((itp1, A1), (itp2, A2), (itp3, A3))
+                check_axes(itp, A, isinplace)
+                check_inbounds_values(itp, A)
+                check_oob(itp)
+                can_eval_near_boundaries(itp)
+            end
+
+            # Evaluation between data points (tests constancy)
+            for i in 2:N1 - 1
+                @test A1[i + 1] == itp1(i + .3) == itp1(i + .6) 
+                @test A1[i] == itp1(i - .3) == itp1(i - .6)
+            end
+            # 2D
+            for i in 2:N1 - 1, j in 2:N1 - 1
+                @test A2[i + 1,j] == itp2(i + .4, j - .3) == itp2(i + .4, j - .6)
+            end
+            # 3D
+            for i in 2:N1 - 1, j in 2:N1 - 1, k in 2:N1 - 1
+                @test A3[i + 1,j,k + 1] == itp3(i + .4, j - .3, k + .1) == itp3(i + .4, j - .3, k + .2)
+            end
         end
     end
 end
+

--- a/test/b-splines/regularization.jl
+++ b/test/b-splines/regularization.jl
@@ -1,0 +1,57 @@
+@testset "Regularization" begin
+    for (constructor, copier) in ((interpolate, identity), (interpolate!, copy))
+        isinplace = constructor == interpolate!
+        f0(x) = sin((x-3)*2pi/9 - 1)
+        f1(x) = 1.0 + 0.1*x + 0.01*x^2 + 0.001*x^3
+
+        xmax = 10
+        xi = range(0, stop=xmax, length=11)
+        xfine = range(0, stop=xmax, length=101)
+
+        A0 = f0.(xi)
+        A1 = f1.(xi)
+
+        for (yi, f) in ((A0, f0), (A1, f1)), λ in (0.01, 100), k in (1, 2, 3, 4)
+            it = @inferred(interpolate(yi, BSpline(Cubic(Line(OnCell()))), λ, k))
+            itt = @inferred(scale(it, xi))
+            
+            if f === f0
+                if λ == 0.01
+                    # test that interpolation of the interpolating points is close to expected data
+                    for x in [2, 3, 6, 7]
+                        @test f(x) ≈ itt(x) atol=0.01
+                    end
+                elseif λ == 100
+                    # test that interpolation of the interpolating points is far from expected data
+                    for x in [2, 3, 6, 7]
+                        @test !(isapprox(f(x), itt(x); atol=0.1))
+                    end
+                end
+            
+            elseif f === f1
+                if k==4
+                    for x in xfine
+                        # test that interpolation is close to expected data when
+                        # the smoothing order is higher than the polynomial order
+                        @test f(x) ≈ itt(x) atol=0.1
+                    end
+                end
+            end
+        end
+
+        # Check fallback to no regularization for λ=0
+        itp1  = @inferred(constructor(copier(A0), BSpline(Cubic(Line(OnGrid()))), 0, 1))
+        itp1p = @inferred(constructor(copier(A0), BSpline(Cubic(Line(OnGrid())))))
+        @test itp1 == itp1p
+
+
+        f2(x, y) = sin(x/10)*cos(y/6)
+        xmax2, ymax2 = 30, 10
+        A2 = Float64[f2(x, y) for x in 1:xmax2, y in 1:ymax2]
+
+        # Check fallback to no regularization for non Vectors
+        itp2  = @inferred(constructor(copier(A2), BSpline(Cubic(Line(OnGrid()))), 1, 1))
+        itp2p = @inferred(constructor(copier(A2), BSpline(Cubic(Line(OnGrid())))))
+        @test itp2 == itp2p
+    end
+end

--- a/test/b-splines/runtests.jl
+++ b/test/b-splines/runtests.jl
@@ -6,6 +6,7 @@
     include("mixed.jl")
     include("multivalued.jl")
     include("non1.jl")
+    include("regularization.jl")
 
     @test eltype(@inferred(interpolate(rand(Float16, 3, 3), BSpline(Linear())))) == Float16 # issue #308
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -8,12 +8,12 @@ using Test
         A = rand(8,20)
 
         itp = interpolate(A, BSpline(Constant()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}())) with element type Float64"
 
         itp = interpolate(A, BSpline(Constant()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}())) with element type Float64"
 
         itp = interpolate(A, BSpline(Linear()))
         @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Linear())) with element type Float64" ||
@@ -47,8 +47,8 @@ using Test
               summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, Gridded(Linear())) with element type Float64"
 
         itp = interpolate(knots, A, (Gridded(Linear()),Gridded(Constant())))
-        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, (Gridded(Linear()), Gridded(Constant()))) with element type Float64" ||
-              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, (Gridded(Linear()), Gridded(Constant()))) with element type Float64"
+        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, (Gridded(Linear()), Gridded(Constant{Nearest}()))) with element type Float64" ||
+              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, (Gridded(Linear()), Gridded(Constant{Nearest}()))) with element type Float64"
 
         # issue #260
         A = (1:4)/4

--- a/test/type-instantiation.jl
+++ b/test/type-instantiation.jl
@@ -68,10 +68,10 @@ for T in (
 end
 # sample one dimspec for each interpolation constructor to see that it
 # calls the construct_instance() function correctly
-@inferred(interpolate(A2, Tuple{BSpline{Linear},BSpline{Constant}}, Tuple{OnGrid,OnCell}))
-@inferred(interpolate!(copy(A2), Tuple{BSpline{Linear},BSpline{Constant}}, Tuple{OnGrid,OnCell}))
-@inferred(interpolate(A2, Tuple{BSpline{Linear},BSpline{Constant}}, (OnGrid(),OnCell())))
-@inferred(interpolate!(copy(A2), Tuple{BSpline{Linear},BSpline{Constant}}, (OnGrid(),OnCell())))
+@inferred(interpolate(A2, Tuple{BSpline{Linear},BSpline{<:Constant}}, Tuple{OnGrid,OnCell}))
+@inferred(interpolate!(copy(A2), Tuple{BSpline{Linear},BSpline{<:Constant}}, Tuple{OnGrid,OnCell}))
+@inferred(interpolate(A2, Tuple{BSpline{Linear},BSpline{<:Constant}}, (OnGrid(),OnCell())))
+@inferred(interpolate!(copy(A2), Tuple{BSpline{Linear},BSpline{<:Constant}}, (OnGrid(),OnCell())))
 @inferred(interpolate(A2, (BSpline(Linear()),BSpline(Constant())), Tuple{OnGrid,OnCell}))
 @inferred(interpolate!(copy(A2), (BSpline(Linear()),BSpline(Constant())), Tuple{OnGrid,OnCell}))
 


### PR DESCRIPTION
I think this part was just trying to promote the type of the fillvalue to something that matches both the coordinates, x, and the coefs. It was doing it in a very strange way. Why not use the standard type promotion machinery?