### PR TITLE
patch_UniftulVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Interpolations"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.13.1"
+version = "0.13.0"
 
 [deps]
 AxisAlgorithms = "13072b0f-2c55-5437-9ae7-d433b7a33950"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Interpolations"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 AxisAlgorithms = "13072b0f-2c55-5437-9ae7-d433b7a33950"

--- a/src/extrapolation/extrapolation.jl
+++ b/src/extrapolation/extrapolation.jl
@@ -53,8 +53,7 @@ count_interp_dims(::Type{<:Extrapolation{T,N,ITPT}}, n) where {T,N,ITPT} = count
 end
 @inline function (etp::Extrapolation{T,N})(x::Vararg{Union{Number,AbstractVector},N}) where {T,N}
     itp = parent(etp)
-    Tret = typeof(lispyprod(zero(T), x...))
-    ret = zeros(Tret, shape(x...))
+    ret = zeros(T, shape(x...))
     for (i, y) in zip(eachindex(ret), Iterators.product(x...))
         ret[i] = etp(y...)
     end

--- a/test/extrapolation/type-stability.jl
+++ b/test/extrapolation/type-stability.jl
@@ -69,4 +69,10 @@ using Test, Interpolations, DualNumbers, Unitful
     @test @inferred(itp(2018)) === 2.0f0 * u
     @test @inferred(etp(2018)) === 2.0f0 * u
     @test @inferred(etp(2019)) === 1.0f0 * u
+
+    # Unitful vector knots
+    t = [0.0, 1.0] * u"m"
+    itp = LinearInterpolation(t, y)
+    @test itp(0.5u"m") == 1.5f0 * u
+    @test itp([0.5, 0.75]u"m") == [1.5f0, 1.75f0] * u
 end


### PR DESCRIPTION
Currently (v0.13.0), this throws:

```julia
using Unitful, Interpolations
x = sort(rand(10))*u"m"
y = rand(10)u"s"
itp = LinearInterpolation(x, y)
itp(0.5u"m") # <- this works
itp([0.5, 0.55]*u"m") # <- this errors
```

because (I think) of the return type being assigned via
https://github.com/JuliaMath/Interpolations.jl/blob/master/src/extrapolation/extrapolation.jl#L56
and ends up being "meters seconds" in the MWE above, which is incorrect.

This PR fixes that by instead assigning the same type as `x` for the return type. Tests passed locally so I assume this is OK :) 
(Although maybe there was a reason for this line before?)