### PR TITLE
Fix parametric spline image URL

### DIFF
--- a/docs/src/control.md
+++ b/docs/src/control.md
@@ -149,4 +149,4 @@ using Plots
 scatter(x, y, label="knots")
 plot!(xs, ys, label="spline")
 ```
-![parametric spline](doc/images/parametric_spline.png)
+![parametric spline](/doc/images/parametric_spline.png)


### PR DESCRIPTION
I'm not 100% sure that this will work, because the image file is outside the `docs` directory. It works in the editing preview but I don't know what will happen when the final renderer runs. If it doesn't work I can copy the image across.