### PR TITLE
Add `knotsbetween` for iterating over interpolation knots

### DIFF
--- a/docs/src/iterate.md
+++ b/docs/src/iterate.md
@@ -254,3 +254,80 @@ julia> size(kiter)
 (4,)
 
 ```
+
+## `knotsbetween`
+
+Given an `AbstractInterpolation` `itp` or results of `knots(itp)` get an iterator
+over knots between `start` and `stop`.
+
+```julia
+using Interpolations
+itp = interpolate(rand(4), options...)
+krange = knotsbetween(itp; start=1.2, stop=3.0)
+collect(kiter) # Array of knots between 1.2 and 3.0
+
+```
+
+We can iterate over all knots greater than `start` by omitting `stop`
+
+```jldoctest knotsbetween-usage; setup = :(using Interpolations)
+julia> x = [1.0, 1.5, 1.75, 2.0];
+
+julia> etp = LinearInterpolation(x, x.^2, extrapolation_bc=Periodic());
+
+julia> krange = knotsbetween(etp; start=4.0);
+
+julia> Iterators.take(krange, 5) |> collect
+5-element Array{Float64,1}:
+ 4.5
+ 4.75
+ 5.0
+ 5.5
+ 5.75
+
+```
+
+If we omit `start`, iteration will range from the first knot to `stop`
+
+```jldoctest knotsbetween-usage
+julia> krange = knotsbetween(etp; stop=4.0);
+
+julia> collect(krange)
+9-element Array{Float64,1}:
+ 1.0
+ 1.5
+ 1.75
+ 2.0
+ 2.5
+ 2.75
+ 3.0
+ 3.5
+ 3.75
+
+```
+
+It is an error to not provided `start` and `stop`
+
+```jldoctest knotsbetween-usage
+julia> knotsbetween(etp)
+ERROR: ArgumentError: At least one of `start` or `stop` must be specified
+[...]
+```
+
+### Multiple Dimensions
+
+When used with a multi-dimensional interpolant, `knotsbetween` can be used to
+iterate overall knots such that: `start[i] < k[i] stop[i]` where `i` indexes
+dimensions.
+
+```jldoctest; setup = :(using Interpolations)
+julia> x = [1.0, 1.5, 1.75, 2.0];
+
+julia> etp = LinearInterpolation((x, x), x.*x');
+
+julia> knotsbetween(etp; start=(1.2, 1.5), stop=(1.8, 3.0)) |> collect
+2×2 Array{Tuple{Float64,Float64},2}:
+ (1.5, 1.75)   (1.5, 2.0)
+ (1.75, 1.75)  (1.75, 2.0)
+
+```

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -41,7 +41,7 @@ using StaticArrays, WoodburyMatrices, Ratios, AxisAlgorithms, OffsetArrays
 using Base: @propagate_inbounds, HasEltype, EltypeUnknown, HasLength, IsInfinite,
     SizeUnknown
 import Base: convert, size, axes, promote_rule, ndims, eltype, checkbounds, axes1,
-    iterate, length, IteratorEltype, IteratorSize
+    iterate, length, IteratorEltype, IteratorSize, firstindex, getindex
 
 abstract type Flag end
 abstract type InterpolationType <: Flag end

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -38,7 +38,8 @@ export
 using LinearAlgebra, SparseArrays
 using StaticArrays, WoodburyMatrices, Ratios, AxisAlgorithms, OffsetArrays
 
-using Base: @propagate_inbounds, HasEltype, HasLength, IsInfinite, SizeUnknown
+using Base: @propagate_inbounds, HasEltype, EltypeUnknown, HasLength, IsInfinite,
+    SizeUnknown
 import Base: convert, size, axes, promote_rule, ndims, eltype, checkbounds, axes1,
     iterate, length, IteratorEltype, IteratorSize
 

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -26,7 +26,8 @@ export
     LinearInterpolation,
     CubicSplineInterpolation,
 
-    knots
+    knots,
+    knotsbetween
 
     # see the following files for further exports:
     # b-splines/b-splines.jl

--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -163,7 +163,7 @@ function iterate(iter::KnotIterator{T, ET}, state) where {T, ET <: FwdExtrapSpec
     curidx, offset = state[1], state[2]
 
     # Increment offset after a forward + backwards pass over the knots
-    cycleidx = mod(curidx, 2*iter.nknots-1)
+    cycleidx = mod(curidx, 2*iter.nknots-2)
     if  cycleidx != 0
         nextstate = (curidx+1, offset)
     else

--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -77,8 +77,9 @@ length(iter::KnotIterator) = _knot_length(iter, IteratorSize(iter))
 _knot_length(iter::KnotIterator, ::HasLength) = iter.nknots
 size(iter::KnotIterator) = (length(iter),)
 
-IteratorEltype(::Type{KnotIterator{T,ET}}) where {T,ET} = HasEltype()
-eltype(::Type{KnotIterator{T,ET}}) where {T,ET} = T
+IteratorEltype(::Type{KnotIterator}) = EltypeUnknown()
+IteratorEltype(::Type{<:KnotIterator{T}}) where {T} = HasEltype()
+eltype(::Type{<:KnotIterator{T}}) where {T} = T
 
 """
     knots(itp::AbstractInterpolation)
@@ -307,7 +308,9 @@ IteratorSize(::Type{KnotRange{T}}) where {T} = SizeUnknown()
 IteratorSize(::Type{KnotRange{T,R}}) where {T, R <: UnitRange} = HasLength()
 IteratorSize(::Type{KnotRange{T,R}}) where {T, R <: Iterators.Count} = IsInfinite()
 
-IteratorEltype(::Type{<:KnotRange}) = HasEltype()
+# If type parameter is not provided -> Eltype is Unknown otherwise known
+IteratorEltype(::Type{<:KnotRange}) = EltypeUnknown()
+IteratorEltype(::Type{<:KnotRange{T}}) where {T} = HasEltype()
 eltype(::Type{<:KnotRange{T}}) where {T} = T
 
 # Dispatch length and size to range

--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -449,8 +449,12 @@ knotsbetween(iter::KnotIterator, start, stop) = KnotRange(iter, start, stop)
 
 # Expand Nothing on Start/Stop if tuples
 function knotsbetween(iter::Iterators.ProductIterator, start::Union{Nothing, Tuple}, stop::Union{Nothing, Tuple})
-    kiter = map_ranges(iter.iterators, start, stop)
-    Iterators.product(kiter...)
+    if start === stop === nothing
+        throw(ArgumentError("At least one of `start` or `stop` must be specified"))
+    else
+        kiter = map_ranges(iter.iterators, start, stop)
+        Iterators.product(kiter...)
+    end
 end
 
 # Map iter, start and stop to N KnotRanges, handling start/stop being nothing

--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -334,13 +334,13 @@ function knotsbetween(iter::Iterators.ProductIterator, start::Union{Nothing, Tup
 end
 
 # Map iter, start and stop to N KnotRanges, handling start/stop being nothing
-function map_ranges(iter, start, ::Nothing)
+function map_ranges(iter, start::Tuple, ::Nothing)
     map((i, s) -> knotsbetween(i, s, nothing), iter, start)
 end
-function map_ranges(iter, ::Nothing, stop)
+function map_ranges(iter, ::Nothing, stop::Tuple)
     map((i, s) -> knotsbetween(i, nothing, s), iter, stop)
 end
-function map_ranges(iter, start, stop)
+function map_ranges(iter, start::Tuple, stop::Tuple)
     map(knotsbetween, iter, start, stop)
 end
 

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -2,6 +2,143 @@ using Test
 using Interpolations
 using Interpolations: KnotRange
 
+"""
+    @test_knots kiter T expect
+
+Generate test sets for testing the knot iterator `kiter`. Following checks are
+performed:
+- `typeof(kiter)` is `T` if 1D or `ProductIterator` wrapping `T` if ND
+- `IteratorEltype` and `eltype` behavior matches expected
+- `IteratorSize`, `length` and `size` are matches expected
+- Iterated contents match (Checks all if bounded, otherwise the first 100)
+"""
+macro test_knots(itersym, type, expect...)
+    # 1D vs ND Checks
+    if length(expect) > 1
+        refExpr = :( Iterators.product($(expect...)) )
+        knotTypeExpr = :( Tuple{ eltype.(($(expect...),))... } )
+        typecheckExpr = quote
+            @test typeof($itersym) <: Iterators.ProductIterator
+            @test typeof($itersym.iterators) <: Tuple{$type, $type}
+        end
+        sizecheckExpr = :( @test size($itersym) == size(ref) )
+
+        # Expect HasShape{N} for ND Iterators
+        IteratorSizeExpr = :( Base.HasShape{$(length(expect))}() )
+    else
+        refExpr = expect[1]
+        knotTypeExpr = :( eltype($refExpr) )
+        typecheckExpr = :( @test (<:)(typeof($itersym), $type) )
+
+        # Check size using length to avoid issues with reference not defining a
+        # suitable size method
+        sizecheckExpr = :( @test size($itersym) == (length(ref),) )
+
+        # Expect a IteratorSize of HasLength for 1D iterators
+        IteratorSizeExpr = :( Base.HasLength() )
+    end
+
+    # Build test_knots tests
+    quote
+        local $itersym = $(esc(itersym))    # Local knot iterator for testing
+        knotType = $(esc(knotTypeExpr))     # Insert Expr to get knot eltype
+        ref = $(esc(refExpr))               # Build reference iterator
+
+        # If the reference size is "SizeUnknown" treat as IsInfinite
+        # Some iterators are quick to assume SizeUnknown
+        isBounded = Base.IteratorSize(ref) != Base.IsInfinite() &&
+                    Base.IteratorSize(ref) != Base.SizeUnknown()
+
+        # Insert Type checks defined earlier
+        @testset "typechecks" begin $typecheckExpr end
+
+        # Check Eltype matches reference iterator
+        # Relax type check (ie. <: instead of ==) as some iterators are quick to
+        # assume "Any" -> Prevents errors caused by ref's type being off
+        # This is okay, as we check that collected eltypes match exactly later
+        @testset "eltype checks" begin
+            @test Base.IteratorEltype($itersym) == Base.HasEltype()
+            @test eltype($itersym) <: knotType
+        end
+
+        # Check that IteratorSize matches reference and iff bounded check that
+        # length matches as well
+        # Size check is defined by $sizecheckExpr to avoid issues with Undefined
+        # size methods for 1D reference iterators
+        @testset "IteratorSize, length and size checks" begin
+            if isBounded
+                @test Base.IteratorSize($itersym) == $IteratorSizeExpr
+                @test length($itersym) == length(ref)
+                $sizecheckExpr
+            else
+                @test Base.IteratorSize($itersym) == Base.IsInfinite()
+            end
+        end
+
+        # Check that the contents of the knot iterator matches the reference
+        # iterator
+        @testset "check contents" begin
+            if isBounded
+                kiter = collect($itersym)
+                kref = collect(ref)
+            else
+                kiter = collect(Iterators.take($itersym, 100))
+                kref = collect(Iterators.take(ref, 100))
+            end
+            # Test Iterator Results
+            @test typeof(kiter) <: AbstractArray
+            @test eltype(kiter) == eltype(kref)
+            @test length(kiter) == length(kref)
+            @test size(kiter) == size(kref)
+            @test map((x,y) -> all(x .≈ y), kiter, kref) |> all
+        end
+
+        # Type stability -> Check that methods are type suitable
+        @testset "type stability" begin
+            @test_skip item, next = @inferred iterate($itersym)
+            @test_skip @inferred iterate($itersym, next)
+        end
+    end
+end
+
+"""
+    knot_ref(seq, etp)
+    knot_ref(seq, etp; start, stop)
+
+Dumb but correct construction of a reference knot iterator for a boundary condition
+of etp.
+
+If start and/or stop is specified, will wrap an dropwhile / takewhile around
+the resulting iterator
+"""
+knot_ref(seq, etp; start=nothing, stop=nothing) = knot_ref(seq, etp, start, stop)
+function knot_ref(seq, etp, start::Number, ::Nothing)
+    # Drop items less than start -> Dispatch to generate sequence
+    Iterators.dropwhile(<=(start), knot_ref(seq, etp))
+end
+function knot_ref(seq, etp, start, stop::Number)
+    # Drop items after stop + collect items (Better IteratorSize /Eltype results)
+    # Dispatch to handle remaining arguments
+    Iterators.takewhile(<(stop), knot_ref(seq, etp, start, nothing)) |> collect
+end
+
+knot_ref(seq, etp, ::Nothing, ::Nothing) = knot_ref(seq, etp)
+
+knot_ref(seq, ::Interpolations.BoundaryCondition) = seq
+
+function knot_ref(seq, ::Periodic)
+    Δ = diff(seq)
+    iter = Iterators.flatten((first(seq), Iterators.cycle(Δ)))
+    Iterators.accumulate(+, iter)
+end
+
+function knot_ref(seq, ::Reflect)
+    Δ = diff(seq)
+    Δ = vcat(Δ, reverse(Δ))
+    iter = Iterators.flatten((first(seq), Iterators.cycle(Δ)))
+    Iterators.accumulate(+, iter)
+end
+
 # Unit Tests for Base.IteratorEltype and Base.IteratorSize methods (Type Info Only)
 @testset "iterate - interface" begin
     import Interpolations.KnotIterator
@@ -212,59 +349,6 @@ end
     @test etp.(k) ≈ vcat(x, reverse(x[1:end - 1]), x[2]).^2
 end
 
-# Test Cases for iteration over the knots of 2D interpolant
-#   itersym Iterator under tests (ie. iter = knots(itp))
-#   type    The iterator type wrapped by Iterators.ProductIterator
-#   expect  One or more iterables for the knots along each dimension
-macro test_knots(itersym, type, expect...)
-
-    # 1D vs ND Checks
-    if length(expect) > 1
-        refExpr = :( Iterators.product($(expect...)) )
-        knotType = eval.(expect) .|> eltype |> x -> Tuple{x...}
-        typecheckExpr = quote
-            @test typeof($itersym) <: Iterators.ProductIterator
-            @test typeof($itersym.iterators) <: Tuple{$type, $type}
-        end
-    else
-        refExpr = :( Iterators.flatten($(expect[1])) )
-        knotType = eval(expect[1]) |> eltype
-        typecheckExpr = :( @test typeof($itersym) <: $type{$knotType} )
-    end
-
-    # Assemble component tests into complete testset
-    quote
-        local $itersym = $(esc(itersym))
-        ref = $refExpr
-        @testset "typechecks" begin $typecheckExpr end
-        @testset "eltype checks" begin
-            @test Base.IteratorEltype($itersym) == Base.HasEltype()
-            @test eltype($itersym) == $knotType
-        end
-        @testset "IteratorSize, length and size checks" begin
-            @test Base.IteratorSize($itersym) == Base.IteratorSize(ref)
-            if Base.IteratorSize(ref) != Base.IsInfinite()
-                @test length($itersym) == length(ref)
-            end
-        end
-        @testset "check contents" begin
-            if Base.IteratorSize(ref) != Base.IsInfinite()
-                kiter = collect($itersym)
-                kref = collect(ref)
-            else
-                kiter = collect(Iterators.take($itersym, 10))
-                kref = collect(Iterators.tail($itersym, 10))
-            end
-            # Test Iterator Results
-            @test typeof(kiter) <: AbstractArray
-            @test eltype(kiter) == $knotType
-            @test length(kiter) == length(kref)
-            @test size(kiter) == size(kref)
-            @test kiter == kref
-        end
-    end
-end
-
 # Unit tests for 2D iteration with directional boundary conditions that are
 # bounded (ie. knots do not repeat indefinitely)
 @testset "2D - iteration - bounded - $bc" for bc ∈ [Line(), (Throw(), Line())]
@@ -317,7 +401,6 @@ end
 
 @testset "knotsbetween - interpolate - 1D" begin
     itp = interpolate(rand(10), BSpline(Linear()))
-
     @testset "start and stop" begin
         krange = knotsbetween(itp; start=2.1, stop=6.2)
         @test_knots krange KnotRange 3:6
@@ -352,3 +435,78 @@ end
     end
 end
 
+@testset "knotsbetween - extrapolate - 1D - $etp" for etp ∈ [Throw(), Flat(), Line()]
+    x = [1.0, 1.5, 1.75, 2.0]
+    etp = LinearInterpolation(x, x.^2, extrapolation_bc=etp)
+    @testset "start and stop" begin
+        krange = knotsbetween(etp; start=0.0, stop=4.2)
+        @test_knots krange KnotRange [1.0, 1.5, 1.75, 2.0]
+    end
+    @testset "start" begin
+        krange = knotsbetween(etp; start=1.2)
+        @test_knots krange KnotRange [1.5, 1.75, 2.0]
+    end
+    @testset "stop" begin
+        krange = knotsbetween(etp; start=1.2)
+        @test_knots krange KnotRange [1.5, 1.75, 2.0]
+    end
+    @testset "empty iterator" begin
+        krange = knotsbetween(etp; start=3)
+        @test_knots krange KnotRange []
+
+        krange = knotsbetween(etp; stop=1.0)
+        @test_knots krange KnotRange []
+    end
+end
+
+@testset "knotsbetween - extrapolate - 1D - Periodic" begin
+    x = [1.0, 1.5, 1.75, 2.0]
+    etp = LinearInterpolation(x, x.^2, extrapolation_bc=Periodic())
+    @testset "start and stop" begin
+        krange = knotsbetween(etp; start=0.0, stop=4.2)
+        expect = knot_ref([0.5, 0.75, 1.0, 1.5], Periodic(); stop=4.2)
+        @test_knots krange KnotRange expect
+        @test all(0.0 .< collect(krange) .< 4.2)
+    end
+    @testset "start" begin
+        krange = knotsbetween(etp; start=3.2)
+        expect = knot_ref([3.5, 3.75, 4.0, 4.5], Periodic())
+        @test_knots krange KnotRange expect
+    end
+    @testset "stop" begin
+        krange = knotsbetween(etp; stop=4.8)
+        expect = knot_ref([1.0, 1.5, 1.75, 2.0], Periodic(); stop=4.8)
+        @test_knots krange KnotRange expect
+        @test all(collect(krange) .< 4.8)
+    end
+    @testset "empty iterator" begin
+        krange = knotsbetween(etp; start=1, stop=1)
+        @test_knots krange KnotRange Float64[]
+    end
+end
+
+@testset "knotsbetween - extrapolate - 1D - Reflect" begin
+    x = [1.0, 1.5, 1.75, 2.0]
+    etp = LinearInterpolation(x, x.^2, extrapolation_bc=Reflect())
+    @testset "start and stop" begin
+        krange = knotsbetween(etp; start=0.0, stop=4.2)
+        expect = knot_ref([0.5, 0.75, 1.0, 1.5], Reflect(); stop=4.2)
+        @test_knots krange KnotRange expect
+        @test all(0.0 .< collect(krange) .< 4.2)
+    end
+    @testset "start" begin
+        krange = knotsbetween(etp; start=3.2)
+        expect = knot_ref([3.5, 3.75, 4.0, 4.5], Reflect())
+        @test_knots krange KnotRange expect
+    end
+    @testset "stop" begin
+        krange = knotsbetween(etp; stop=4.8)
+        expect = knot_ref([1.0, 1.5, 1.75, 2.0], Reflect(); stop=4.8)
+        @test_knots krange KnotRange expect
+        @test all(collect(krange) .< 4.8)
+    end
+    @testset "empty iterator" begin
+        krange = knotsbetween(etp; start=1, stop=1)
+        @test_knots krange KnotRange []
+    end
+end

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -198,11 +198,12 @@ end
     @test Base.IteratorEltype(KnotRange) == Base.HasEltype()
     @test Base.IteratorEltype(KnotRange{Int}) == Base.HasEltype()
 
-    # IteratorSize Stored Directly in KnotRange Type
+    # If missing Range type parameter -> SizeUnknown, as could be HasLength or
+    # IsInfinite
     @test Base.IteratorSize(KnotRange) == Base.SizeUnknown()
     @test Base.IteratorSize(KnotRange{Int}) == Base.SizeUnknown()
-    @test Base.IteratorSize(KnotRange{Int,Base.IsInfinite}) == Base.IsInfinite()
-    @test Base.IteratorSize(KnotRange{Int,Base.HasLength}) == Base.HasLength()
+    @test Base.IteratorSize(KnotRange{Int,Base.UnitRange}) == Base.HasLength()
+    @test Base.IteratorSize(KnotRange{Int,Iterators.Count}) == Base.IsInfinite()
 end
 
 # eltype units tests of KnotIterator / KnotRange
@@ -475,44 +476,44 @@ end
     x = [1.0, 1.5, 1.75, 2.0]
     etp = LinearInterpolation(x, x.^2, extrapolation_bc=Periodic())
     krange = knotsbetween(etp; stop = 10)
-    using Interpolations: _knot_start, _knot_stop
+    using Interpolations: nextknotidx, priorknotidx
 
-    @test_knot_idx _knot_start krange -2.1 -8 -2.0
-    @test_knot_idx _knot_start krange 0.4 -1 0.5
-    @test_knot_idx _knot_start krange 0.7 0 0.75
-    @test_knot_idx _knot_start krange 0.8 1 1.0
-    @test_knot_idx _knot_start krange 1.0 2 1.5
-    @test_knot_idx _knot_start krange 1.5 3 1.75
-    @test_knot_idx _knot_start krange 2.3 5 2.5
+    @test_knot_idx(nextknotidx, krange, -2.1, -8, -2.0)
+    @test_knot_idx(nextknotidx, krange, 0.4, -1, 0.5)
+    @test_knot_idx(nextknotidx, krange, 0.7, 0, 0.75)
+    @test_knot_idx(nextknotidx, krange, 0.8, 1, 1.0)
+    @test_knot_idx(nextknotidx, krange, 1.0, 2, 1.5)
+    @test_knot_idx(nextknotidx, krange, 1.5, 3, 1.75)
+    @test_knot_idx(nextknotidx, krange, 2.3, 5, 2.5)
 
-    @test_knot_idx _knot_stop krange 0.4 -2 0.0
-    @test_knot_idx _knot_stop krange 0.7 -1 0.5
-    @test_knot_idx _knot_stop krange 0.8 0 0.75
-    @test_knot_idx _knot_stop krange 1.0 0 0.75
-    @test_knot_idx _knot_stop krange 1.5 1 1.0
-    @test_knot_idx _knot_stop krange 2.0 3 1.75
-    @test_knot_idx _knot_stop krange 2.3 4 2.0
+    @test_knot_idx(priorknotidx, krange, 0.4, -2, 0.0)
+    @test_knot_idx(priorknotidx, krange, 0.7, -1, 0.5)
+    @test_knot_idx(priorknotidx, krange, 0.8, 0, 0.75)
+    @test_knot_idx(priorknotidx, krange, 1.0, 0, 0.75)
+    @test_knot_idx(priorknotidx, krange, 1.5, 1, 1.0)
+    @test_knot_idx(priorknotidx, krange, 2.0, 3, 1.75)
+    @test_knot_idx(priorknotidx, krange, 2.3, 4, 2.0)
 end
 
 @testset "_knot_start/stop - Reflect" begin
     x = [1.0, 1.5, 1.75, 2.0]
     etp = LinearInterpolation(x, x.^2, extrapolation_bc=Reflect())
     krange = knotsbetween(etp; stop = 10)
-    using Interpolations: _knot_start, _knot_stop
+    using Interpolations: nextknotidx, priorknotidx
 
-    @test_knot_idx _knot_start krange -2.1 -8 -2.0
-    @test_knot_idx _knot_start krange 0.2 -1 0.25
-    @test_knot_idx _knot_start krange 1.6 3 1.75
-    @test_knot_idx _knot_start krange 3.75 10 4.0
-    @test_knot_idx _knot_start krange 5.4 14 5.5
+    @test_knot_idx(nextknotidx, krange, -2.1, -8, -2.0)
+    @test_knot_idx(nextknotidx, krange, 0.2, -1, 0.25)
+    @test_knot_idx(nextknotidx, krange, 1.6, 3, 1.75)
+    @test_knot_idx(nextknotidx, krange, 3.75, 10, 4.0)
+    @test_knot_idx(nextknotidx, krange, 5.4, 14, 5.5)
 
-    @test_knot_idx _knot_stop krange 0.4 -1 0.25
-    @test_knot_idx _knot_stop krange 0.7 0 0.5
-    @test_knot_idx _knot_stop krange 4.3 11 4.25
-    @test_knot_idx _knot_stop krange 6.3 17 6.25
-    @test_knot_idx _knot_stop krange 1.5 1 1.0
-    @test_knot_idx _knot_stop krange 8.2 22 8.0
-    @test_knot_idx _knot_stop krange 10.0 27 9.75
+    @test_knot_idx(priorknotidx, krange, 0.4, -1, 0.25)
+    @test_knot_idx(priorknotidx, krange, 0.7, 0, 0.5)
+    @test_knot_idx(priorknotidx, krange, 4.3, 11, 4.25)
+    @test_knot_idx(priorknotidx, krange, 6.3, 17, 6.25)
+    @test_knot_idx(priorknotidx, krange, 1.5, 1, 1.0)
+    @test_knot_idx(priorknotidx, krange, 8.2, 22, 8.0)
+    @test_knot_idx(priorknotidx, krange, 10.0, 27, 9.75)
 end
 
 @testset "knotsbetween - extrapolate - 1D - Periodic" begin

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -452,11 +452,33 @@ end
     end
     @testset "empty iterator" begin
         krange = knotsbetween(etp; start=3)
-        @test_knots krange KnotRange []
+        @test_knots krange KnotRange Float64[]
 
         krange = knotsbetween(etp; stop=1.0)
-        @test_knots krange KnotRange []
+        @test_knots krange KnotRange Float64[]
     end
+end
+
+@testset "_knot_start/stop - Periodic" begin
+    x = [1.0, 1.5, 1.75, 2.0]
+    etp = LinearInterpolation(x, x.^2, extrapolation_bc=Periodic())
+    krange = knotsbetween(etp; stop = 1)
+    using Interpolations: _knot_start, _knot_stop
+
+    @test _knot_start(krange, 0.4) == (-1, -1.0)
+    @test _knot_start(krange, 0.7) == (0, -1.0)
+    @test _knot_start(krange, 0.8) == (1, 0.0)
+    @test _knot_start(krange, 1.0) == (2, 0.0)
+    @test _knot_start(krange, 1.5) == (3, 0.0)
+    @test _knot_start(krange, 2.3) == (5, 1.0)
+
+    @test _knot_stop(krange, 0.4) == (-2, -1.0)
+    @test _knot_stop(krange, 0.7) == (-1, -1.0)
+    @test _knot_stop(krange, 0.8) == (0, -1.0)
+    @test _knot_stop(krange, 1.0) == (0, -1.0)
+    @test _knot_stop(krange, 1.5) == (1, 0.0)
+    @test _knot_stop(krange, 2.0) == (3, 0.0)
+    @test _knot_stop(krange, 2.3) == (4, 1.0)
 end
 
 @testset "knotsbetween - extrapolate - 1D - Periodic" begin
@@ -490,13 +512,13 @@ end
     etp = LinearInterpolation(x, x.^2, extrapolation_bc=Reflect())
     @testset "start and stop" begin
         krange = knotsbetween(etp; start=0.0, stop=4.2)
-        expect = knot_ref([0.5, 0.75, 1.0, 1.5], Reflect(); stop=4.2)
+        expect = knot_ref([-1.0, -0.5, -0.25, 0.0], Reflect(); start=0.0, stop=4.2)
         @test_knots krange KnotRange expect
         @test all(0.0 .< collect(krange) .< 4.2)
     end
     @testset "start" begin
         krange = knotsbetween(etp; start=3.2)
-        expect = knot_ref([3.5, 3.75, 4.0, 4.5], Reflect())
+        expect = knot_ref([3.0, 3.5, 3.75, 4.0], Reflect(); start=3.2)
         @test_knots krange KnotRange expect
     end
     @testset "stop" begin
@@ -507,6 +529,6 @@ end
     end
     @testset "empty iterator" begin
         krange = knotsbetween(etp; start=1, stop=1)
-        @test_knots krange KnotRange []
+        @test_knots krange KnotRange Float64[]
     end
 end

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -95,8 +95,13 @@ macro test_knots(itersym, type, expect...)
 
         # Type stability -> Check that methods are type suitable
         @testset "type stability" begin
-            @test_skip item, next = @inferred iterate($itersym)
-            @test_skip @inferred iterate($itersym, next)
+            iteratetype = Union{Nothing, knotType}
+            y = @inferred iteratetype iterate($itersym)
+            if y !== nothing
+                @test_nowarn @inferred iteratetype iterate($itersym, y[2])
+            end
+            isBounded && @test_nowarn @inferred Integer length($itersym)
+            @test_nowarn @inferred Type eltype($itersym)
         end
     end
 end
@@ -472,21 +477,21 @@ end
     krange = knotsbetween(etp; stop = 10)
     using Interpolations: _knot_start, _knot_stop
 
-    @test_knot_idx _knot_start krange -2.1 (-8, -3.0) -2.0
-    @test_knot_idx _knot_start krange 0.4 (-1, -1.0) 0.5
-    @test_knot_idx _knot_start krange 0.7 (0, -1.0) 0.75
-    @test_knot_idx _knot_start krange 0.8 (1, 0.0) 1.0
-    @test_knot_idx _knot_start krange 1.0 (2, 0.0) 1.5
-    @test_knot_idx _knot_start krange 1.5 (3, 0.0) 1.75
-    @test_knot_idx _knot_start krange 2.3 (5, 1.0) 2.5
+    @test_knot_idx _knot_start krange -2.1 -8 -2.0
+    @test_knot_idx _knot_start krange 0.4 -1 0.5
+    @test_knot_idx _knot_start krange 0.7 0 0.75
+    @test_knot_idx _knot_start krange 0.8 1 1.0
+    @test_knot_idx _knot_start krange 1.0 2 1.5
+    @test_knot_idx _knot_start krange 1.5 3 1.75
+    @test_knot_idx _knot_start krange 2.3 5 2.5
 
-    @test_knot_idx _knot_stop krange 0.4 (-2, -1.0) 0.0
-    @test_knot_idx _knot_stop krange 0.7 (-1, -1.0) 0.5
-    @test_knot_idx _knot_stop krange 0.8 (0, -1.0) 0.75
-    @test_knot_idx _knot_stop krange 1.0 (0, -1.0) 0.75
-    @test_knot_idx _knot_stop krange 1.5 (1, 0.0) 1.0
-    @test_knot_idx _knot_stop krange 2.0 (3, 0.0) 1.75
-    @test_knot_idx _knot_stop krange 2.3 (4, 1.0) 2.0
+    @test_knot_idx _knot_stop krange 0.4 -2 0.0
+    @test_knot_idx _knot_stop krange 0.7 -1 0.5
+    @test_knot_idx _knot_stop krange 0.8 0 0.75
+    @test_knot_idx _knot_stop krange 1.0 0 0.75
+    @test_knot_idx _knot_stop krange 1.5 1 1.0
+    @test_knot_idx _knot_stop krange 2.0 3 1.75
+    @test_knot_idx _knot_stop krange 2.3 4 2.0
 end
 
 @testset "_knot_start/stop - Reflect" begin
@@ -495,19 +500,19 @@ end
     krange = knotsbetween(etp; stop = 10)
     using Interpolations: _knot_start, _knot_stop
 
-    @test_knot_idx _knot_start krange -2.1 (-8, -4.0) -2.0
-    @test_knot_idx _knot_start krange 0.2 (-1, -2.0) 0.25
-    @test_knot_idx _knot_start krange 1.6 (3, 0.0) 1.75
-    @test_knot_idx _knot_start krange 3.75 (10, 2.0) 4.0
-    @test_knot_idx _knot_start krange 5.4 (14, 4.0) 5.5
+    @test_knot_idx _knot_start krange -2.1 -8 -2.0
+    @test_knot_idx _knot_start krange 0.2 -1 0.25
+    @test_knot_idx _knot_start krange 1.6 3 1.75
+    @test_knot_idx _knot_start krange 3.75 10 4.0
+    @test_knot_idx _knot_start krange 5.4 14 5.5
 
-    @test_knot_idx _knot_stop krange 0.4 (-1, -2.0) 0.25
-    @test_knot_idx _knot_stop krange 0.7 (0, -2.0) 0.5
-    @test_knot_idx _knot_stop krange 4.3 (11, 2.0) 4.25
-    @test_knot_idx _knot_stop krange 6.3 (17, 4.0) 6.25
-    @test_knot_idx _knot_stop krange 1.5 (1, 0.0) 1.0
-    @test_knot_idx _knot_stop krange 8.2 (22, 6.0) 8.0
-    @test_knot_idx _knot_stop krange 10.0 (27, 8.0) 9.75
+    @test_knot_idx _knot_stop krange 0.4 -1 0.25
+    @test_knot_idx _knot_stop krange 0.7 0 0.5
+    @test_knot_idx _knot_stop krange 4.3 11 4.25
+    @test_knot_idx _knot_stop krange 6.3 17 6.25
+    @test_knot_idx _knot_stop krange 1.5 1 1.0
+    @test_knot_idx _knot_stop krange 8.2 22 8.0
+    @test_knot_idx _knot_stop krange 10.0 27 9.75
 end
 
 @testset "knotsbetween - extrapolate - 1D - Periodic" begin

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -180,9 +180,10 @@ end
 # Unit Tests for Base.IteratorEltype and Base.IteratorSize methods (Type Info Only)
 @testset "iterate - interface" begin
     import Interpolations.KnotIterator
-    # Always have an eltype as we explicitly track via T
-    @test Base.IteratorEltype(KnotIterator) == Base.HasEltype()
+    # Eletype is known iff type parameter is provided
+    @test Base.IteratorEltype(KnotIterator) == Base.EltypeUnknown()
     @test Base.IteratorEltype(KnotIterator{Int}) == Base.HasEltype()
+    @test Base.IteratorEltype(KnotIterator{Int,Flat}) == Base.HasEltype()
 
     # If missing ET type parameter -> SizeUnknown, as could be HasLength or
     # IsInfinite
@@ -194,9 +195,11 @@ end
 # Iterator Interface for KnotRange
 @testset "KnotRange - iterate interface" begin
     import Interpolations.KnotRange
-    # Always have an eltype as we explicitly track via T
-    @test Base.IteratorEltype(KnotRange) == Base.HasEltype()
+    # Eletype is known iff type parameter is provided
+    @test Base.IteratorEltype(KnotRange) == Base.EltypeUnknown()
     @test Base.IteratorEltype(KnotRange{Int}) == Base.HasEltype()
+    @test Base.IteratorEltype(KnotRange{Int,Base.UnitRange}) == Base.HasEltype()
+    @test Base.IteratorEltype(KnotRange{Int,Iterators.Count}) == Base.HasEltype()
 
     # If missing Range type parameter -> SizeUnknown, as could be HasLength or
     # IsInfinite

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -592,3 +592,20 @@ end
         @test_knots krange KnotRange Float64[]
     end
 end
+
+@testset "knotsbetween - empty iterator" begin
+    x = [1.0, 1.5, 1.75, 2.0]
+    etp = LinearInterpolation(x, x.^2)
+    @testset "start is out of bounds" begin
+        krange = knotsbetween(etp; start=2.0)
+        @test_knots krange KnotRange Float64[]
+    end
+    @testset "start and stop and out of bounds" begin
+        krange = knotsbetween(etp; start=-10, stop=0)
+        @test_knots krange KnotRange Float64[]
+    end
+    @testset "stop is less than start" begin
+        krange = knotsbetween(etp; start=1.8, stop=1.1)
+        @test_knots krange KnotRange Float64[]
+    end
+end


### PR DESCRIPTION
This pull request adds a `knotsbetween(itp; start, stop)` method for iterating over knots between `start` and `stop`

The existing `KnotIterator` was reworked to be indexable instead of using a tuple of `(index, offset)` when iterating
- This gives a large speed bump (Like ~4x based on one-off tests)
- Eliminated type instability issues caused by using both `Int` and `(Int, Any)` for the iteration state

## Fixes
Bug Fix: Prior `KnotIterator` would yield incorrect results for `Reflect` boundary condition
- Fixed by e7d9d58
- Error occurs after iterating over 2+ cycles -> Expanded test to check the first 100 knots (~16 cycles)
- Added @test_knots macro to simplify testing (And drive up the number of tests)

Fix: Corrected `IteratorEltype` to return `UnknownEltype` if Type parameter not include  (ie. `KnotIterator` vs `KnotIterator{T}`
- Fixed by 39a7923
- Impact is minimal as `eltype` would return `Any` and the `Any` is used if the eltype is unknown

## Other New Things
`KnotIterator` is now indexable, I've added an example to the Developer's documentation, but kept it out of the rest of the docs as support is limited

- Indexing doesn't work for Multidimensional Interpolations (As `KnotIterators` get wrapped in a `ProductIterator`)
- Indexing is only defined for `Int`, so slice indexing doesn't work
- It does get exported because `Base.getindex` is imported by `filter1d.jl`. _Should this be removed now that it's in `Interpolatons.jl`?_
