### PR TITLE
Narrow compatibility requirements for StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ WoodburyMatrices = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
 AxisAlgorithms = "0.3, 1"
 OffsetArrays = "0.10, 0.11, 1.0.1"
 Ratios = "0.3, 0.4"
-StaticArrays = "0.10, 0.11, 0.12, 1.0"
+StaticArrays = "0.12, 1"
 WoodburyMatrices = "0.4, 0.5"
 julia = "1"
 


### PR DESCRIPTION
Currently, `using Interpolations` fails with StaticArrays 0.10 and 0.11
due to the missing `StaticArrays.SA` value. This PR removes the claimed
compatibility to avoid users accidentally getting a broken installation.

We'll also need to edit the General registry to apply this compatibility
fix to Interpolations.jl v0.13.0 and v0.13.1 otherwise the package
resolver will incorrectly want to downgrade to those versions if a user
has an older StaticArrays version.