### PR TITLE
Convenience constructors for constant (nearest-neighbor) interpolation

### DIFF
--- a/docs/src/convenience-construction.md
+++ b/docs/src/convenience-construction.md
@@ -1,8 +1,9 @@
 
 ## Convenience notation
 
-For linear and cubic spline interpolations, `LinearInterpolation` and `CubicSplineInterpolation`
-can be used to create interpolating and extrapolating objects handily:
+For constant, linear, and cubic spline interpolations, `ConstantInterpolation`, `LinearInterpolation`, and `CubicSplineInterpolation`
+can be used to create interpolating and extrapolating objects handily.
+
 ```julia
 f(x) = log(x)
 xs = 1:0.2:5
@@ -55,7 +56,7 @@ extrap = LinearInterpolation(xs, A, extrapolation_bc = NaN)
 @test isnan(extrap(5.2))
 ```
 
-Irregular grids are supported as well; note that presently only `LinearInterpolation` supports irregular grids.
+Irregular grids are supported as well; note that presently only `ConstantInterpolation` and `LinearInterpolation` supports irregular grids.
 ```julia
 xs = [x^2 for x = 1:0.2:5]
 A = [f(x) for x in xs]

--- a/docs/src/convenience-construction.md
+++ b/docs/src/convenience-construction.md
@@ -4,6 +4,19 @@
 For constant, linear, and cubic spline interpolations, `ConstantInterpolation`, `LinearInterpolation`, and `CubicSplineInterpolation`
 can be used to create interpolating and extrapolating objects handily.
 
+### Motivating Example
+By using the convenience constructor one can simplify expressions. For example, the creation of an interpolation object 
+```julia
+extrap_full = extrapolate(scale(interpolate(A, BSpline(Linear())), xs), Line())
+```
+can be written as the more readable
+```julia
+extrap = LinearInterpolation(xs, A, extrapolation_bc = Line())
+ ```
+ by using the convenience constructor.
+ 
+ ### Usage
+
 ```julia
 f(x) = log(x)
 xs = 1:0.2:5

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -23,6 +23,7 @@ export
     InPlaceQ,
     Throw,
 
+    ConstantInterpolation,
     LinearInterpolation,
     CubicSplineInterpolation,
 

--- a/src/convenience-constructors.jl
+++ b/src/convenience-constructors.jl
@@ -1,5 +1,9 @@
-# convenience copnstructors for linear / cubic spline interpolations
+# convenience copnstructors for constant / linear / cubic spline interpolations
 # 1D version
+ConstantInterpolation(range::AbstractRange, vs::AbstractVector; extrapolation_bc = Throw()) =
+    extrapolate(scale(interpolate(vs, BSpline(Constant())), range), extrapolation_bc)
+ConstantInterpolation(range::AbstractVector, vs::AbstractVector; extrapolation_bc = Throw()) =
+    extrapolate(interpolate((range, ), vs, Gridded(Constant())), extrapolation_bc)
 LinearInterpolation(range::AbstractRange, vs::AbstractVector; extrapolation_bc = Throw()) =
     extrapolate(scale(interpolate(vs, BSpline(Linear())), range), extrapolation_bc)
 LinearInterpolation(range::AbstractVector, vs::AbstractVector; extrapolation_bc = Throw()) =
@@ -9,6 +13,12 @@ CubicSplineInterpolation(range::AbstractRange, vs::AbstractVector;
     extrapolate(scale(interpolate(vs, BSpline(Cubic(bc))), range), extrapolation_bc)
 
 # multivariate versions
+ConstantInterpolation(ranges::NTuple{N,AbstractRange}, vs::AbstractArray{T,N};
+                    extrapolation_bc = Throw()) where {N,T} =
+    extrapolate(scale(interpolate(vs, BSpline(Constant())), ranges...), extrapolation_bc)
+ConstantInterpolation(ranges::NTuple{N,AbstractVector}, vs::AbstractArray{T,N};
+                    extrapolation_bc = Throw()) where {N,T} =
+    extrapolate(interpolate(ranges, vs, Gridded(Constant())), extrapolation_bc)
 LinearInterpolation(ranges::NTuple{N,AbstractRange}, vs::AbstractArray{T,N};
                     extrapolation_bc = Throw()) where {N,T} =
     extrapolate(scale(interpolate(vs, BSpline(Linear())), ranges...), extrapolation_bc)
@@ -27,6 +37,15 @@ where `scheme` is either `BSpline(Linear())` or `Gridded(Linear())` depending on
 `knots` are ranges or vectors.
 """
 LinearInterpolation
+
+"""
+    etp = ConstantInterpolation(knots, A; extrapolation_bc=Throw())
+
+A shorthand for `extrapolate(interpolate(knots, A, scheme), extrapolation_bc)`,
+where `scheme` is either `BSpline(Constant())` or `Gridded(Constant())` depending on whether
+`knots` are ranges or vectors.
+"""
+ConstantInterpolation
 
 """
     etp = CubicSplineInterpolation(knots, A; bc=Line(OnGrid()), extrapolation_bc=Throw())

--- a/test/convenience-constructors.jl
+++ b/test/convenience-constructors.jl
@@ -83,6 +83,24 @@ YLEN = convert(Integer, floor((YMAX - YMIN)/ΔY) + 1)
         @test_throws BoundsError interp(xmin - ΔX / 2)
         @test_throws BoundsError interp(xmax + ΔX / 2)
     end
+    
+    @testset "1d-irregular-grids-constant" begin
+        xs = [x^2 for x in XMIN:ΔX:XMAX]
+        xmin = xs[1]
+        xmax = xs[XLEN]
+        f(x) = log(x)
+        A = [f(x) for x in xs]
+        interp = ConstantInterpolation(xs, A)
+        interp_full = extrapolate(interpolate((xs, ), A, Gridded(Constant())), Throw())
+
+        @test typeof(interp) == typeof(interp_full)
+        @test interp(xmin) ≈ f(xmin)
+        @test interp(xmax) ≈ f(xmax)
+        @test interp(xs[2]) ≈ f(xs[2])
+        @test interp(xmin + ΔX / 2) ≈ f(xmin + ΔX / 2) atol=.1
+        @test_throws BoundsError interp(xmin - ΔX / 2)
+        @test_throws BoundsError interp(xmax + ΔX / 2)
+    end
 
     @testset "1d-handling-extrapolation" begin
         xs = XMIN:ΔX:XMAX
@@ -183,6 +201,33 @@ end
         A = [f(x,y) for x in xs, y in ys]
         interp = LinearInterpolation((xs, ys), A)
         interp_full = extrapolate(interpolate((xs, ys), A, Gridded(Linear())), Throw())
+
+        @test typeof(interp) == typeof(interp_full)
+        @test interp(xmin,ymin) ≈ f(xmin,ymin)
+        @test interp(xmin,ymax) ≈ f(xmin,ymax)
+        @test interp(xmax,ymin) ≈ f(xmax,ymin)
+        @test interp(xmax,ymax) ≈ f(xmax,ymax)
+        @test interp(xs[2],ymin) ≈ f(xs[2],ymin)
+        @test interp(xmin,ys[2]) ≈ f(xmin,ys[2])
+        @test interp(xs[2],ys[2]) ≈ f(xs[2],ys[2])
+        @test interp(xmin + ΔX / 2,ymin + ΔY / 2) ≈ f(xmin + ΔX / 2,ymin + ΔY / 2) atol=.1
+        @test_throws BoundsError interp(xmin - ΔX / 2,ymin - ΔY / 2)
+        @test_throws BoundsError interp(xmin - ΔX / 2,ymin + ΔY / 2)
+        @test_throws BoundsError interp(xmin + ΔX / 2,ymin - ΔY / 2)
+        @test_throws BoundsError interp(xmax + ΔX / 2,ymax + ΔY / 2)
+    end
+    
+    @testset "2d-irregular-grids-constant" begin
+        xs = [x^2 for x in XMIN:ΔX:XMAX]
+        ys = [y^2 for y in YMIN:ΔY:YMAX]
+        xmin = xs[1]
+        xmax = xs[XLEN]
+        ymin = ys[1]
+        ymax = ys[YLEN]
+        f(x, y) = log(x+y)
+        A = [f(x,y) for x in xs, y in ys]
+        interp = ConstantInterpolation((xs, ys), A)
+        interp_full = extrapolate(interpolate((xs, ys), A, Gridded(Constant())), Throw())
 
         @test typeof(interp) == typeof(interp_full)
         @test interp(xmin,ymin) ≈ f(xmin,ymin)

--- a/test/convenience-constructors.jl
+++ b/test/convenience-constructors.jl
@@ -31,6 +31,23 @@ YLEN = convert(Integer, floor((YMAX - YMIN)/ΔY) + 1)
         @test_throws BoundsError interp(XMIN - ΔX / 2)
         @test_throws BoundsError interp(XMAX + ΔX / 2)
     end
+    
+    @testset "1d-regular-grids-constant" begin
+        xs = XMIN:ΔX:XMAX
+        f(x) = log(x)
+        A = [f(x) for x in xs]
+        interp = ConstantInterpolation(xs, A) # using convenience constructor
+        interp_full = extrapolate(scale(interpolate(A, BSpline(Constant())), xs), Throw()) # using full constructor
+
+        @test typeof(interp) == typeof(interp_full)
+        @test interp(XMIN) ≈ f(XMIN)
+        @test interp(XMAX) ≈ f(XMAX)
+        @test interp(XMIN + ΔX) ≈ f(XMIN + ΔX)
+        @test interp(XMAX - ΔX) ≈ f(XMAX - ΔX)
+        @test interp(XMIN + ΔX / 2) ≈ f(XMIN + ΔX / 2) atol=.1
+        @test_throws BoundsError interp(XMIN - ΔX / 2)
+        @test_throws BoundsError interp(XMAX + ΔX / 2)
+    end
 
     @testset "1d-regular-grids-cubic" begin
         xs = XMIN:ΔX:XMAX
@@ -93,6 +110,29 @@ end
         A = [f(x,y) for x in xs, y in ys]
         interp = LinearInterpolation((xs, ys), A)
         interp_full = extrapolate(scale(interpolate(A, BSpline(Linear())), xs, ys), Throw())
+
+        @test typeof(interp) == typeof(interp_full)
+        @test interp(XMIN,YMIN) ≈ f(XMIN,YMIN)
+        @test interp(XMIN,YMAX) ≈ f(XMIN,YMAX)
+        @test interp(XMAX,YMIN) ≈ f(XMAX,YMIN)
+        @test interp(XMAX,YMAX) ≈ f(XMAX,YMAX)
+        @test interp(XMIN + ΔX,YMIN) ≈ f(XMIN + ΔX,YMIN)
+        @test interp(XMIN,YMIN + ΔY) ≈ f(XMIN,YMIN + ΔY)
+        @test interp(XMIN + ΔX,YMIN + ΔY) ≈ f(XMIN + ΔX,YMIN + ΔY)
+        @test interp(XMIN + ΔX / 2,YMIN + ΔY / 2) ≈ f(XMIN + ΔX / 2,YMIN + ΔY / 2) atol=.1
+        @test_throws BoundsError interp(XMIN - ΔX / 2,YMIN - ΔY / 2)
+        @test_throws BoundsError interp(XMIN - ΔX / 2,YMIN + ΔY / 2)
+        @test_throws BoundsError interp(XMIN + ΔX / 2,YMIN - ΔY / 2)
+        @test_throws BoundsError interp(XMAX + ΔX / 2,YMAX + ΔY / 2)
+    end
+    
+    @testset "2d-regular-grids-constant" begin
+        xs = XMIN:ΔX:XMAX
+        ys = YMIN:ΔY:YMAX
+        f(x, y) = log(x+y)
+        A = [f(x,y) for x in xs, y in ys]
+        interp = ConstantInterpolation((xs, ys), A)
+        interp_full = extrapolate(scale(interpolate(A, BSpline(Constant())), xs, ys), Throw())
 
         @test typeof(interp) == typeof(interp_full)
         @test interp(XMIN,YMIN) ≈ f(XMIN,YMIN)


### PR DESCRIPTION
Unless there is some specific reason for this not be in the code, I don't see why this shouldn't be included.

If you want to merge the pull request, I'd be happy to update the docs and tests.