### PR TITLE
Compatibility with ChainRules, Drop Julia 1.0 support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.13.1"
 
 [deps]
 AxisAlgorithms = "13072b0f-2c55-5437-9ae7-d433b7a33950"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["OffsetArrays", "Unitful", "SharedArrays", "ForwardDiff", "LinearAlgebra", "DualNumbers", "Random", "Test"]
+test = ["OffsetArrays", "Unitful", "SharedArrays", "ForwardDiff", "LinearAlgebra", "DualNumbers", "Random", "Test", "Zygote"]

--- a/docs/src/chainrules.md
+++ b/docs/src/chainrules.md
@@ -1,0 +1,18 @@
+## ChainRulesCore Integration
+
+The `WeightedIndex` infrastructure has issues working with autodiff libraries. Autodiff is facilitate by integration with ChainRulesCore. A custom [rrule](https://juliadiff.org/ChainRulesCore.jl/dev/index.html) is definied such that
+
+```julia
+y, itp_pullback = rrule(itp, 1)
+```
+`itp_pullback` takes a purturbation on `y` and returns how it effects each `x` dimension. Since `Interpolations` already has a `gradient` function, `pullback` reuses it by scaling it by `Δy`.
+
+This enables integration with autodiff libraries like Zygote, enabling
+
+```julia
+x = 1:10
+y = sin.(x)
+itp = interpolate(y,BSpline(Linear()))
+Zygote.gradient(itp, 2)
+#([-0.7681774187658145],)
+```

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -38,6 +38,7 @@ export
 
 using LinearAlgebra, SparseArrays
 using StaticArrays, WoodburyMatrices, Ratios, AxisAlgorithms, OffsetArrays
+using ChainRulesCore
 
 using Base: @propagate_inbounds, HasEltype, EltypeUnknown, HasLength, IsInfinite,
     SizeUnknown
@@ -481,5 +482,6 @@ include("convenience-constructors.jl")
 include("deprecations.jl")
 include("lanczos/lanczos.jl")
 include("iterate.jl")
+include("chainrules/chainrules.jl")
 
 end # module

--- a/src/chainrules/chainrules.jl
+++ b/src/chainrules/chainrules.jl
@@ -1,8 +1,12 @@
 export rrule
+"""
+    ChainRulesCore.rrule(itp::AbstractInterpolation, x...)
+ChainRulesCore.jl `rrule` for integration with automatic differentiation libraries.
+"""
 function ChainRulesCore.rrule(itp::AbstractInterpolation, x...)
     y = itp(x...)
-    function back(Δ)
-        (NO_FIELDS, Δ * Interpolations.gradient(itp, x...))
+    function pullback(Δy)
+        (NO_FIELDS, Δy * Interpolations.gradient(itp, x...))
     end
-    y, back
+    y, pullback
 end

--- a/src/chainrules/chainrules.jl
+++ b/src/chainrules/chainrules.jl
@@ -1,0 +1,8 @@
+export rrule
+function ChainRulesCore.rrule(itp::AbstractInterpolation, x...)
+    y = itp(x...)
+    function back(Δ)
+        (NO_FIELDS, Δ * gradient(itp, x...))
+    end
+    y, back
+end

--- a/src/chainrules/chainrules.jl
+++ b/src/chainrules/chainrules.jl
@@ -2,7 +2,7 @@ export rrule
 function ChainRulesCore.rrule(itp::AbstractInterpolation, x...)
     y = itp(x...)
     function back(Δ)
-        (NO_FIELDS, Δ * gradient(itp, x...))
+        (NO_FIELDS, Δ * Interpolations.gradient(itp, x...))
     end
     y, back
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,0 +1,10 @@
+using Zygote
+
+x = collect(1:10)
+y = sin.(x)
+
+# Simple test that rrules give equivalent results to internal gradient function
+
+itp = interpolate(y,BSpline(Linear()))
+
+@test Zygote.gradient(itp, 1)[1] == Interpolations.gradient(itp, 1)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,10 +1,19 @@
 using Zygote
+@testset "ChainRulesCore" begin
+    # 1D example
+    x = 1:10
+    y = sin.(x)
 
-x = collect(1:10)
-y = sin.(x)
+    # Simple test that rrules give equivalent results to internal gradient function
 
-# Simple test that rrules give equivalent results to internal gradient function
+    itp = interpolate(y,BSpline(Linear()))
 
-itp = interpolate(y,BSpline(Linear()))
+    @test Zygote.gradient(itp, 1)[1] == Interpolations.gradient(itp, 1)
 
-@test Zygote.gradient(itp, 1)[1] == Interpolations.gradient(itp, 1)
+    # 2D example
+    x2 = [i*j for i=1:5, j=1:5]
+    y2 = sin.(x2)
+
+    itp2 = interpolate(y2, BSpline(Cubic(Line(OnGrid()))))
+    @test Zygote.gradient(itp2,1,2)[1] == Interpolations.gradient(itp2,1,2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,4 +51,6 @@ const isci = get(ENV, "CI", "") in ("true", "True")
     include("readme-examples.jl")
     include("iterate.jl")
 
+    # Chain rules interaction
+    include("chainrules.jl")
 end


### PR DESCRIPTION
related to #396. As mentioned by @moesphere in that thread, we need to define a rrule for the Interolations type. I've defined a simple rrule which enables me to integrate with, for example, Zygote like this:

```julia
julia> using Interpolations

julia> y = sin.(1:10)
10-element Vector{Float64}:
  0.8414709848078965
  0.9092974268256817
  0.1411200080598672
 -0.7568024953079282
 -0.9589242746631385
 -0.27941549819892586
  0.6569865987187891
  0.9893582466233818
  0.4121184852417566
 -0.5440211108893698

julia> itp = interpolate(y,BSpline(Cubic(Reflect(OnCell()))))
10-element interpolate(OffsetArray(::Vector{Float64}, 0:11), BSpline(Cubic(Reflect(OnCell())))) with element type Float64:
  0.7125302276762112
  0.769963450028415
  0.1194958272928704
 -0.6408357079724973
 -0.8119858486932346
 -0.23659994479000876
  0.556314857216602
  0.8377563450756788
  0.3489685127835064
 -0.29399432638595374

julia> Zygote.gradient(itp, 2)
([-0.35017548837401463],)

julia> Interpolations.gradient(itp, 2)
1-element StaticArrays.SVector{1, Float64} with indices SOneTo(1):
 -0.35017548837401463
```

This should allow us to integrate with Flux. 