### PR TITLE
Periodic boundary conditions for Linear and Constant

### DIFF
--- a/docs/src/extrapolation.md
+++ b/docs/src/extrapolation.md
@@ -12,3 +12,28 @@ itp = interpolate(1:7, BSpline(Linear()))
 etpf = extrapolate(itp, Flat())   # gives 1 on the left edge and 7 on the right edge
 etp0 = extrapolate(itp, 0)        # gives 0 everywhere outside [1,7]
 ```
+
+### Periodic extrapolation
+
+For uniformly sampled periodic data, one can perform periodic extrapolation for all types of
+B-Spline interpolations. By using the `Periodic(OnCell())` boundary condition in `interpolate`,
+one does not need to include the periodic image of the starting sample point.
+
+Examples:
+
+```julia
+f(x) = sin((x-3)*2pi/7 - 1)
+A = Float64[f(x) for x in 1:7] # Does not include the periodic image
+
+# Constant(Periodic())) is an alias for Constant{Nearest}(Periodic(OnCell()))
+itp0 = interpolate(A, BSpline(Constant(Periodic())))
+# Linear(Periodic())) is an alias for Linear(Periodic(OnCell()))
+itp1 = interpolate(A, BSpline(Linear(Periodic())))
+itp2 = interpolate(A, BSpline(Quadratic(Periodic(OnCell()))))
+itp3 = interpolate(A, BSpline(Cubic(Periodic(OnCell()))))
+
+etp0 = extrapolate(itp0, Periodic())
+etp1 = extrapolate(itp1, Periodic())
+etp2 = extrapolate(itp2, Periodic())
+etp3 = extrapolate(itp3, Periodic())
+```

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -254,6 +254,6 @@ include("indexing.jl")
 include("prefiltering.jl")
 include("../filter1d.jl")
 
-Base.parent(A::BSplineInterpolation{T,N,TCoefs,UT}) where {T,N,TCoefs,UT<:Union{BSpline{Linear},BSpline{<:Constant}}} = A.coefs
+Base.parent(A::BSplineInterpolation{T,N,TCoefs,UT}) where {T,N,TCoefs,UT<:Union{BSpline{<:Linear},BSpline{<:Constant}}} = A.coefs
 Base.parent(A::BSplineInterpolation{T,N,TCoefs,UT}) where {T,N,TCoefs,UT} =
     throw(ArgumentError("The given BSplineInterpolation does not serve as a \"view\" for a parent array. This would only be true for Constant and Linear b-splines."))

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -5,8 +5,24 @@ struct Nearest <: ConstantInterpType end
 struct Previous <: ConstantInterpType end
 struct Next <: ConstantInterpType end
 
-struct Constant{T<:ConstantInterpType} <: Degree{0} end
+# struct Constant{T<:ConstantInterpType} <: Degree{0} end
+# Constant() = Constant{Nearest}()
+
+struct Constant{T<:ConstantInterpType,BC<:Union{Throw{OnGrid},Periodic{OnCell}}} <: DegreeBC{0}
+    bc::BC
+end
+
+# Default to Nearest and Throw{OnGrid}
 Constant() = Constant{Nearest}()
+Constant(bc::BoundaryCondition) = Constant{Nearest}(bc)
+Constant{T}() where {T<:ConstantInterpType} = Constant{T,Throw{OnGrid}}(Throw(OnGrid()))
+Constant{T}(bc::BC) where {T<:ConstantInterpType,BC<:BoundaryCondition} = Constant{T,BC}(bc)
+
+function Base.show(io::IO, deg::Constant)
+    print(io, nameof(typeof(deg)), '{', typeof(deg).parameters[1], '}', '(')
+    show(io, deg.bc)
+    print(io, ')')
+end
 
 """
 Constant b-splines are *nearest-neighbor* interpolations, and effectively
@@ -28,6 +44,19 @@ function positions(c::Constant{Nearest}, ax, x)  # discontinuity occurs at half-
     xm = roundbounds(x, ax)
     δx = x - xm
     fast_trunc(Int, xm), δx
+end
+
+function positions(c::Constant{Previous,Periodic{OnCell}}, ax, x)
+    # We do not use floorbounds because we do not want to add a half at
+    # the lowerbound to round up.
+    xm = floor(x)
+    δx = x - xm
+    modrange(fast_trunc(Int, xm), ax), δx
+end
+function positions(c::Constant{Next,Periodic{OnCell}}, ax, x)  # discontinuity occurs at integer locations
+    xm = ceilbounds(x, ax)
+    δx = x - xm
+    modrange(fast_trunc(Int, xm), ax), δx
 end
 
 value_weights(::Constant, δx) = (1,)

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -5,9 +5,6 @@ struct Nearest <: ConstantInterpType end
 struct Previous <: ConstantInterpType end
 struct Next <: ConstantInterpType end
 
-# struct Constant{T<:ConstantInterpType} <: Degree{0} end
-# Constant() = Constant{Nearest}()
-
 struct Constant{T<:ConstantInterpType,BC<:Union{Throw{OnGrid},Periodic{OnCell}}} <: DegreeBC{0}
     bc::BC
 end

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -10,10 +10,10 @@ struct Constant{T<:ConstantInterpType,BC<:Union{Throw{OnGrid},Periodic{OnCell}}}
 end
 
 # Default to Nearest and Throw{OnGrid}
-Constant() = Constant{Nearest}()
-Constant(bc::BoundaryCondition) = Constant{Nearest}(bc)
+Constant(args...) = Constant{Nearest}(args...)
 Constant{T}() where {T<:ConstantInterpType} = Constant{T,Throw{OnGrid}}(Throw(OnGrid()))
 Constant{T}(bc::BC) where {T<:ConstantInterpType,BC<:BoundaryCondition} = Constant{T,BC}(bc)
+Constant{T}(::Periodic{Nothing}) where {T<:ConstantInterpType} = Constant{T,Periodic{OnCell}}(Periodic(OnCell()))
 
 function Base.show(io::IO, deg::Constant)
     print(io, nameof(typeof(deg)), '{', typeof(deg).parameters[1], '}', '(')

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -21,6 +21,10 @@ function Base.show(io::IO, deg::Constant)
     print(io, ')')
 end
 
+function Base.show(io::IO, deg::Constant{T,Throw{OnGrid}}) where {T <: ConstantInterpType}
+    print(io, nameof(typeof(deg)), '{', typeof(deg).parameters[1], '}', '(', ')')
+end
+
 """
 Constant b-splines are *nearest-neighbor* interpolations, and effectively
 return `A[round(Int,x)]` when interpolating.

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -4,6 +4,7 @@ end
 
 (deg::Linear)(gt::GridType) = Linear(deg.bc(gt))
 Linear() = Linear(Throw(OnGrid()))
+Linear(::Periodic{Nothing}) = Linear(Periodic(OnCell()))
 
 """
     Linear()

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -1,4 +1,9 @@
-struct Linear <: Degree{1} end  # boundary conditions not supported
+struct Linear{BC<:Union{Throw{OnGrid},Periodic{OnCell}}} <: DegreeBC{1}
+    bc::BC
+end
+
+(deg::Linear)(gt::GridType) = Linear(deg.bc(gt))
+Linear() = Linear(Throw(OnGrid()))
 
 """
     Linear()
@@ -27,16 +32,19 @@ a piecewise linear function connecting each pair of neighboring data points.
 """
 Linear
 
-function positions(::Linear, ax::AbstractUnitRange{<:Integer}, x)
+function positions(deg::Linear, ax::AbstractUnitRange{<:Integer}, x)
     f = floor(x)
     # When x == last(ax) we want to use the x-1, x pair
     f = ifelse(x == last(ax), f - oneunit(f), f)
     fi = fast_trunc(Int, f)
-    return fi, x-f
+    expand_index(deg, fi, ax), x-f
 end
+expand_index(::Linear{Throw{OnGrid}}, fi::Number, ax::AbstractUnitRange) = fi
+expand_index(::Linear{Periodic{OnCell}}, fi::Number, ax::AbstractUnitRange) =
+    (modrange(fi, ax), modrange(fi+1, ax))
 
 value_weights(::Linear, δx) = (1-δx, δx)
 gradient_weights(::Linear, δx) = (-oneunit(δx), oneunit(δx))
 hessian_weights(::Linear, δx) = (zero(δx), zero(δx))
 
-padded_axis(ax::AbstractUnitRange, ::BSpline{Linear}) = ax
+padded_axis(ax::AbstractUnitRange, ::BSpline{<:Linear}) = ax

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -2,7 +2,6 @@ struct Linear{BC<:Union{Throw{OnGrid},Periodic{OnCell}}} <: DegreeBC{1}
     bc::BC
 end
 
-(deg::Linear)(gt::GridType) = Linear(deg.bc(gt))
 Linear() = Linear(Throw(OnGrid()))
 Linear(::Periodic{Nothing}) = Linear(Periodic(OnCell()))
 

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -6,6 +6,10 @@ end
 Linear() = Linear(Throw(OnGrid()))
 Linear(::Periodic{Nothing}) = Linear(Periodic(OnCell()))
 
+function Base.show(io::IO, deg::Linear{Throw{OnGrid}})
+    print(io, nameof(typeof(deg)), '(', ')')
+end
+
 """
     Linear()
 

--- a/test/b-splines/constant.jl
+++ b/test/b-splines/constant.jl
@@ -126,8 +126,10 @@
         for T in (Nearest, Previous, Next)
             it = Constant{T}()
             @test it isa Constant{T, Throw{OnGrid}}
+            @test "$it" == "Constant{$T}()"
             it = Constant{T}(Periodic())
             @test it isa Constant{T, Periodic{OnCell}}
+            @test "$it" == "Constant{$T}(Periodic(OnCell()))"
         end
 
         for (constructor, copier) in ((interpolate, x -> x), (interpolate!, copy))

--- a/test/extrapolation/periodic.jl
+++ b/test/extrapolation/periodic.jl
@@ -1,0 +1,23 @@
+
+@testset "Periodic extrapolation" begin
+    xmax = 7
+    f(x) = sin((x-3)*2pi/xmax - 1)
+    A = Float64[f(x) for x in 1:xmax] # Does not include the periodic image
+
+    itp0 = interpolate(A, BSpline(Constant(Periodic())))
+    itp1 = interpolate(A, BSpline(Linear(Periodic())))
+    itp2 = interpolate(A, BSpline(Quadratic(Periodic(OnCell()))))
+    itp3 = interpolate(A, BSpline(Cubic(Periodic(OnCell()))))
+
+    etp0 = extrapolate(itp0, Periodic())
+    etp1 = extrapolate(itp1, Periodic())
+    etp2 = extrapolate(itp2, Periodic())
+    etp3 = extrapolate(itp3, Periodic())
+
+    for x in -xmax:.4:2*xmax
+        @test etp0(x) ≈ f(x) atol=0.5
+        @test etp1(x) ≈ f(x) atol=0.1
+        @test etp2(x) ≈ f(x) atol=0.01
+        @test etp3(x) ≈ f(x) atol=0.003
+    end
+end

--- a/test/extrapolation/runtests.jl
+++ b/test/extrapolation/runtests.jl
@@ -107,4 +107,5 @@ using Test
 
     include("type-stability.jl")
     include("non1.jl")
+    include("periodic.jl")
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -8,24 +8,24 @@ using Test
         A = rand(8,20)
 
         itp = interpolate(A, BSpline(Constant()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64"
 
         itp = interpolate(A, BSpline(Constant()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64"
 
         itp = interpolate(A, BSpline(Linear()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Linear())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Linear())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Linear(Throw(OnGrid())))) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Linear(Throw(OnGrid())))) with element type Float64"
 
         itp = interpolate(A, BSpline(Quadratic(Reflect(OnCell()))))
         @test summary(itp) == "8×20 interpolate(OffsetArray(::Matrix{Float64}, 0:9, 0:21), BSpline(Quadratic(Reflect(OnCell())))) with element type Float64" ||
               summary(itp) == "8×20 interpolate(OffsetArray(::Array{Float64,2}, 0:9, 0:21), BSpline(Quadratic(Reflect(OnCell())))) with element type Float64"
 
         itp = interpolate(A, (BSpline(Linear()), NoInterp()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, (BSpline(Linear()), NoInterp())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, (BSpline(Linear()), NoInterp())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, (BSpline(Linear(Throw(OnGrid()))), NoInterp())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, (BSpline(Linear(Throw(OnGrid()))), NoInterp())) with element type Float64"
 
         itp = interpolate!(copy(A), BSpline(Quadratic(InPlace(OnCell()))))
         @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Quadratic(InPlace(OnCell())))) with element type Float64" ||
@@ -37,18 +37,18 @@ using Test
         A_x = collect(1.0:2.0:40.0)
         knots = (A_x,)
         itp = interpolate(knots, A, Gridded(Linear()))
-        @test summary(itp) == "20-element interpolate((::Vector{Float64},), ::Vector{Float64}, Gridded(Linear())) with element type Float64" ||
-              summary(itp) == "20-element interpolate((::Array{Float64,1},), ::Array{Float64,1}, Gridded(Linear())) with element type Float64"
+        @test summary(itp) == "20-element interpolate((::Vector{Float64},), ::Vector{Float64}, Gridded(Linear(Throw(OnGrid())))) with element type Float64" ||
+              summary(itp) == "20-element interpolate((::Array{Float64,1},), ::Array{Float64,1}, Gridded(Linear(Throw(OnGrid())))) with element type Float64"
 
         A = rand(8,20)
         knots = ([x^2 for x = 1:8], [0.2y for y = 1:20])
         itp = interpolate(knots, A, Gridded(Linear()))
-        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, Gridded(Linear())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, Gridded(Linear())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, Gridded(Linear(Throw(OnGrid())))) with element type Float64" ||
+              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, Gridded(Linear(Throw(OnGrid())))) with element type Float64"
 
         itp = interpolate(knots, A, (Gridded(Linear()),Gridded(Constant())))
-        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, (Gridded(Linear()), Gridded(Constant{Nearest}()))) with element type Float64" ||
-              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, (Gridded(Linear()), Gridded(Constant{Nearest}()))) with element type Float64"
+        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, (Gridded(Linear(Throw(OnGrid()))), Gridded(Constant{Nearest}(Throw(OnGrid()))))) with element type Float64" ||
+              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, (Gridded(Linear(Throw(OnGrid()))), Gridded(Constant{Nearest}(Throw(OnGrid()))))) with element type Float64"
 
         # issue #260
         A = (1:4)/4
@@ -56,15 +56,15 @@ using Test
         io = IOBuffer()
         show(io, MIME("text/plain"), itp)
         str1 = String(take!(io))
-        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear())) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
-        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear()))withelementtypeFloat64:\n 0.25 \n 0.5 \n 0.75\n 1.0"
+        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear(Throw(OnGrid())))) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
+        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear(Throw(OnGrid()))))withelementtypeFloat64:\n 0.25 \n 0.5 \n 0.75\n 1.0"
         @test filter(!isspace, str1) == filter(!isspace, str3) ||
               filter(!isspace, str1) == filter(!isspace, str2)
         io2 = IOBuffer()
         show(io2, itp)
         str1 = String(take!(io2))
-        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear())) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
-        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear()))withelementtypeFloat64:\n 0.25\n 0.5\n 0.75\n 1.0"
+        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear(Throw(OnGrid())))) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
+        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear(Throw(OnGrid()))))withelementtypeFloat64:\n 0.25\n 0.5\n 0.75\n 1.0"
         @test filter(!isspace, str1) == filter(!isspace, str3) ||
               filter(!isspace, str1) == filter(!isspace, str2)
     end
@@ -72,18 +72,18 @@ using Test
     @testset "scaled" begin
         itp = interpolate(1:1.0:10, BSpline(Linear()))
         sitp = scale(itp, -3:.5:1.5)
-        @test summary(sitp) == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64" ||
-              summary(sitp) == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64"
+        @test summary(sitp) == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64" ||
+              summary(sitp) == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64"
         io = IOBuffer()
         show(io, MIME("text/plain"), sitp)
         str = String(take!(io))
-        @test str == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
-              str == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
+        @test str == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
+              str == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
         io2 = IOBuffer()
         show(io2, sitp)
         str2 = String(take!(io2))
-        @test str2 == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
-              str2 == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
+        @test str2 == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
+              str2 == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
 
         gauss(phi, mu, sigma) = exp(-(phi-mu)^2 / (2sigma)^2)
         testfunction(x,y) = gauss(x, 0.5, 4) * gauss(y, -.5, 2)
@@ -126,8 +126,8 @@ using Test
 
         itpg = interpolate(A, BSpline(Linear()))
         etpg = extrapolate(itpg, Flat())
-        teststring = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear())), Flat()) with element type Float64"
-        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear())), Flat()) with element type Float64"
+        teststring = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear(Throw(OnGrid())))), Flat()) with element type Float64"
+        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear(Throw(OnGrid())))), Flat()) with element type Float64"
         @test summary(etpg) == teststring16 || summary(etpg) == teststring
         io = IOBuffer()
         show(io, etpg)
@@ -135,8 +135,8 @@ using Test
         @test occursin(teststring16, str) || occursin(teststring, str)
 
         etpf = extrapolate(itpg, NaN)
-        teststring2 = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear())), NaN) with element type Float64"
-        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear())), NaN) with element type Float64"
+        teststring2 = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear(Throw(OnGrid())))), NaN) with element type Float64"
+        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear(Throw(OnGrid())))), NaN) with element type Float64"
         @test summary(etpf) == teststring16 || summary(etpf) == teststring2
         io2 = IOBuffer()
         show(io2, etpf)

--- a/test/io.jl
+++ b/test/io.jl
@@ -8,24 +8,24 @@ using Test
         A = rand(8,20)
 
         itp = interpolate(A, BSpline(Constant()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}())) with element type Float64"
 
         itp = interpolate(A, BSpline(Constant()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}(Throw(OnGrid())))) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Constant{Nearest}())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Constant{Nearest}())) with element type Float64"
 
         itp = interpolate(A, BSpline(Linear()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Linear(Throw(OnGrid())))) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Linear(Throw(OnGrid())))) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Linear())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, BSpline(Linear())) with element type Float64"
 
         itp = interpolate(A, BSpline(Quadratic(Reflect(OnCell()))))
         @test summary(itp) == "8×20 interpolate(OffsetArray(::Matrix{Float64}, 0:9, 0:21), BSpline(Quadratic(Reflect(OnCell())))) with element type Float64" ||
               summary(itp) == "8×20 interpolate(OffsetArray(::Array{Float64,2}, 0:9, 0:21), BSpline(Quadratic(Reflect(OnCell())))) with element type Float64"
 
         itp = interpolate(A, (BSpline(Linear()), NoInterp()))
-        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, (BSpline(Linear(Throw(OnGrid()))), NoInterp())) with element type Float64" ||
-              summary(itp) == "8×20 interpolate(::Array{Float64,2}, (BSpline(Linear(Throw(OnGrid()))), NoInterp())) with element type Float64"
+        @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, (BSpline(Linear()), NoInterp())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate(::Array{Float64,2}, (BSpline(Linear()), NoInterp())) with element type Float64"
 
         itp = interpolate!(copy(A), BSpline(Quadratic(InPlace(OnCell()))))
         @test summary(itp) == "8×20 interpolate(::Matrix{Float64}, BSpline(Quadratic(InPlace(OnCell())))) with element type Float64" ||
@@ -37,18 +37,18 @@ using Test
         A_x = collect(1.0:2.0:40.0)
         knots = (A_x,)
         itp = interpolate(knots, A, Gridded(Linear()))
-        @test summary(itp) == "20-element interpolate((::Vector{Float64},), ::Vector{Float64}, Gridded(Linear(Throw(OnGrid())))) with element type Float64" ||
-              summary(itp) == "20-element interpolate((::Array{Float64,1},), ::Array{Float64,1}, Gridded(Linear(Throw(OnGrid())))) with element type Float64"
+        @test summary(itp) == "20-element interpolate((::Vector{Float64},), ::Vector{Float64}, Gridded(Linear())) with element type Float64" ||
+              summary(itp) == "20-element interpolate((::Array{Float64,1},), ::Array{Float64,1}, Gridded(Linear())) with element type Float64"
 
         A = rand(8,20)
         knots = ([x^2 for x = 1:8], [0.2y for y = 1:20])
         itp = interpolate(knots, A, Gridded(Linear()))
-        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, Gridded(Linear(Throw(OnGrid())))) with element type Float64" ||
-              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, Gridded(Linear(Throw(OnGrid())))) with element type Float64"
+        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, Gridded(Linear())) with element type Float64" ||
+              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, Gridded(Linear())) with element type Float64"
 
         itp = interpolate(knots, A, (Gridded(Linear()),Gridded(Constant())))
-        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, (Gridded(Linear(Throw(OnGrid()))), Gridded(Constant{Nearest}(Throw(OnGrid()))))) with element type Float64" ||
-              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, (Gridded(Linear(Throw(OnGrid()))), Gridded(Constant{Nearest}(Throw(OnGrid()))))) with element type Float64"
+        @test summary(itp) == "8×20 interpolate((::Vector{Int64},::Vector{Float64}), ::Matrix{Float64}, (Gridded(Linear()), Gridded(Constant{Nearest}()))) with element type Float64" ||
+              summary(itp) == "8×20 interpolate((::Array{Int64,1},::Array{Float64,1}), ::Array{Float64,2}, (Gridded(Linear()), Gridded(Constant{Nearest}()))) with element type Float64"
 
         # issue #260
         A = (1:4)/4
@@ -56,15 +56,15 @@ using Test
         io = IOBuffer()
         show(io, MIME("text/plain"), itp)
         str1 = String(take!(io))
-        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear(Throw(OnGrid())))) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
-        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear(Throw(OnGrid()))))withelementtypeFloat64:\n 0.25 \n 0.5 \n 0.75\n 1.0"
+        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear())) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
+        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear()))withelementtypeFloat64:\n 0.25 \n 0.5 \n 0.75\n 1.0"
         @test filter(!isspace, str1) == filter(!isspace, str3) ||
               filter(!isspace, str1) == filter(!isspace, str2)
         io2 = IOBuffer()
         show(io2, itp)
         str1 = String(take!(io2))
-        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear(Throw(OnGrid())))) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
-        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear(Throw(OnGrid()))))withelementtypeFloat64:\n 0.25\n 0.5\n 0.75\n 1.0"
+        str2 = "4-element interpolate((0.0:0.1:0.3,), ::Array{Float64,1}, Gridded(Linear())) with element type Float64:\n 0.25\n 0.5 \n 0.75\n 1.0"
+        str3 = "4-elementinterpolate((0.0:0.1:0.3,),::Vector{Float64},Gridded(Linear()))withelementtypeFloat64:\n 0.25\n 0.5\n 0.75\n 1.0"
         @test filter(!isspace, str1) == filter(!isspace, str3) ||
               filter(!isspace, str1) == filter(!isspace, str2)
     end
@@ -72,18 +72,18 @@ using Test
     @testset "scaled" begin
         itp = interpolate(1:1.0:10, BSpline(Linear()))
         sitp = scale(itp, -3:.5:1.5)
-        @test summary(sitp) == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64" ||
-              summary(sitp) == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64"
+        @test summary(sitp) == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64" ||
+              summary(sitp) == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64"
         io = IOBuffer()
         show(io, MIME("text/plain"), sitp)
         str = String(take!(io))
-        @test str == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
-              str == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
+        @test str == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
+              str == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
         io2 = IOBuffer()
         show(io2, sitp)
         str2 = String(take!(io2))
-        @test str2 == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
-              str2 == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear(Throw(OnGrid())))), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
+        @test str2 == "10-element scale(interpolate(::Vector{Float64}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0" ||
+              str2 == "10-element scale(interpolate(::Array{Float64,1}, BSpline(Linear())), (-3.0:0.5:1.5,)) with element type Float64:\n  1.0\n  2.0\n  3.0\n  4.0\n  5.0\n  6.0\n  7.0\n  8.0\n  9.0\n 10.0"
 
         gauss(phi, mu, sigma) = exp(-(phi-mu)^2 / (2sigma)^2)
         testfunction(x,y) = gauss(x, 0.5, 4) * gauss(y, -.5, 2)
@@ -126,8 +126,8 @@ using Test
 
         itpg = interpolate(A, BSpline(Linear()))
         etpg = extrapolate(itpg, Flat())
-        teststring = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear(Throw(OnGrid())))), Flat()) with element type Float64"
-        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear(Throw(OnGrid())))), Flat()) with element type Float64"
+        teststring = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear())), Flat()) with element type Float64"
+        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear())), Flat()) with element type Float64"
         @test summary(etpg) == teststring16 || summary(etpg) == teststring
         io = IOBuffer()
         show(io, etpg)
@@ -135,8 +135,8 @@ using Test
         @test occursin(teststring16, str) || occursin(teststring, str)
 
         etpf = extrapolate(itpg, NaN)
-        teststring2 = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear(Throw(OnGrid())))), NaN) with element type Float64"
-        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear(Throw(OnGrid())))), NaN) with element type Float64"
+        teststring2 = "8×20 extrapolate(interpolate(::Array{Float64,2}, BSpline(Linear())), NaN) with element type Float64"
+        teststring16 = "8×20 extrapolate(interpolate(::Matrix{Float64}, BSpline(Linear())), NaN) with element type Float64"
         @test summary(etpf) == teststring16 || summary(etpf) == teststring2
         io2 = IOBuffer()
         show(io2, etpf)


### PR DESCRIPTION
As discussed in #326, this PR enables periodic linear and constant interpolation without adding additional points.

The major change is that `Linear` and `Constant` are now subtypes of DegreeBC. The boundary conditions can only be `Throw(OnGrid())` or `Periodic(OnCell())` because others does not make sense or are redundant.

Existing constructors keeps working. Periodic constant and linear interpolations can be constructed similarly to cubic ones, e.g. `Linear(Periodic(OnCell()))`.

# Examples

### Example 1 (taken from https://github.com/JuliaMath/Interpolations.jl/issues/326#issuecomment-505220728)
```Julia
using Interpolations
using PyPlot
fig, axes = subplots(1, 2, figsize=(8, 4))
f(x) = sin(x)
xs = range(0, stop=2pi, length=10)[1:end-1] # note that we don't want the overlapping point at 2pi
A = f.(xs);
for i in 1:2
    sca(axes[i])
    if i == 1
        title("old")
        itp = interpolate(A, BSpline(Linear()), OnGrid()) # Old
    else
        title("new")
        itp = interpolate(A, BSpline(Linear(Periodic(OnCell())))) # New
    end
    stp = scale(itp, xs) # re-scale to the actual domain
    etp = extrapolate(stp, Periodic()) # extrapolate periodically

    xs_long = range(-2pi, stop=4pi, length=100)
    A_long = [etp[x] for x in xs_long]
    plot(xs, A, "o", label="Data")
    plot(xs_long, A_long, label="Extrapolated")
    plot(xs_long, sin.(xs_long), label="sin(x)")
    legend(loc="lower left")
end
display(gcf()); clf()
close(fig)
```

![image](https://user-images.githubusercontent.com/32537613/119788410-156ee000-bf0d-11eb-8445-08ec8ce874f3.png)

### Example 2

```Julia
using Interpolations
using PyPlot
f(x) = sin(2π * x + 0.5)
df(x) = 2π * cos(2π * x + 0.5)
N = 5
x = range(0, 1, length=N+1)[1:end-1]
y = f.(x)
degs = reshape([
    Constant(),
    Constant{Previous}(),
    Constant{Next}(),
    Linear(),
    Constant(Periodic(OnCell())),
    Constant{Previous}(Periodic(OnCell())),
    Constant{Next}(Periodic(OnCell())),
    Linear(Periodic(OnCell()))
    ], 4, 2)
fig, axes_ = subplots(size(degs)..., figsize=(12, 8), sharex=true, sharey=true)
for (i, deg) in enumerate(degs)
    sca(axes_[i])
    itp = interpolate(y, BSpline(deg));
    zero_to_one = range(0, 1, length=N+1)[1:end-1]
    stp = scale(itp, zero_to_one);
    etp = extrapolate(stp, Periodic());
    xx = range(-0.5, 2.5, step=0.001);
    plot(xx, etp.(xx), "C0-", label="Interpolated")
    plot(x, y, "ko", label="Data")
    plot(xx, f.(xx), "k--", label="Exact")
    # Plot derivatives
    if i in [4, 8]
        plot(xx, Interpolations.gradient.(Ref(etp), xx) ./ 5, "C1-")
        plot(xx, df.(xx) ./ 5, "y--")
    end
    title("$deg")
    if i == 1
        legend(loc="lower right")
    end
end
display(gcf()); clf()
close(fig)
```

Plots on the right side are the new features. The orange (yellow) lines are the interpolated (exact) derivatives.

![image](https://user-images.githubusercontent.com/32537613/119795412-67b2ff80-bf13-11eb-8a2e-2069a8fe0a48.png)

# TODO

- [x] Documentation
- [x] Add tests
- [x] Add convenience constructor `Linear(Periodic()) = Linear(Periodic(OnCell()))`?

closes #326