### PR TITLE
support zero-arg parametric constructor for Constant and Linear

### DIFF
--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -7,6 +7,9 @@ struct Next <: ConstantInterpType end
 
 struct Constant{T<:ConstantInterpType,BC<:Union{Throw{OnGrid},Periodic{OnCell}}} <: DegreeBC{0}
     bc::BC
+    function Constant{T, BC}(bc::BC=BC()) where {T<:ConstantInterpType, BC<:Union{Throw{OnGrid},Periodic{OnCell}}}
+        new{T, BC}(bc)
+    end
 end
 
 # Default to Nearest and Throw{OnGrid}

--- a/src/b-splines/linear.jl
+++ b/src/b-splines/linear.jl
@@ -1,9 +1,13 @@
 struct Linear{BC<:Union{Throw{OnGrid},Periodic{OnCell}}} <: DegreeBC{1}
     bc::BC
+    function Linear{BC}(bc::BC=BC()) where BC<:Union{Throw{OnGrid},Periodic{OnCell}}
+        new{BC}(bc)
+    end
 end
 
 Linear() = Linear(Throw(OnGrid()))
 Linear(::Periodic{Nothing}) = Linear(Periodic(OnCell()))
+Linear(bc::BC) where BC<:Union{Throw{OnGrid},Periodic{OnCell}} = Linear{BC}(bc)
 
 function Base.show(io::IO, deg::Linear{Throw{OnGrid}})
     print(io, nameof(typeof(deg)), '(', ')')

--- a/test/b-splines/constant.jl
+++ b/test/b-splines/constant.jl
@@ -119,9 +119,9 @@
 
     @testset "Constant periodic" begin
         # Constructors
-        @test Constant() === Constant(Throw(OnGrid()))
+        @test Constant() === Constant(Throw(OnGrid())) === Constant{Nearest,Throw{OnGrid}}()
         @test Constant() isa Constant{Nearest,Throw{OnGrid}}
-        @test Constant(Periodic()) === Constant(Periodic(OnCell()))
+        @test Constant(Periodic()) === Constant(Periodic(OnCell())) === Constant{Nearest,Periodic{OnCell}}()
         @test Constant(Periodic()) isa Constant{Nearest,Periodic{OnCell}}
         for T in (Nearest, Previous, Next)
             it = Constant{T}()

--- a/test/b-splines/linear.jl
+++ b/test/b-splines/linear.jl
@@ -64,9 +64,9 @@
 
     @testset "Linear periodic" begin
         # Constructors
-        @test Linear() === Linear(Throw(OnGrid()))
+        @test Linear() === Linear(Throw(OnGrid())) === Linear{Throw{OnGrid}}()
         @test Linear() isa Linear{Throw{OnGrid}}
-        @test Linear(Periodic()) === Linear(Periodic(OnCell()))
+        @test Linear(Periodic()) === Linear(Periodic(OnCell())) == Linear{Periodic{OnCell}}()
         @test Linear(Periodic()) isa Linear{Periodic{OnCell}}
 
         xmax = 10


### PR DESCRIPTION
ImageTransformations uses [`typeof(deg)()` internally](https://github.com/JuliaImages/ImageTransformations.jl/blob/c66b77a7e742ddd3f592395a2f983492a290e3ed/src/compat.jl#L27-L34) and it assumes the zero argument version constructor `Linear{Throw{OnGrid}}()` and `Constant{Nearest,Throw{OnGrid}}()` exist. So Interpolations v0.13.3 unfortunately breaks ImageTransformations 😢 

I'm not sure if the `bc` field is necessary. (See my comments in https://github.com/JuliaMath/Interpolations.jl/pull/428/files#r668457028). This patch assumes that `bc` is needed and I added these constructor methods.

---

https://github.com/JuliaImages/ImageTransformations.jl/pull/132 fixes the issue in ImageTransformations side, but I believe this is still useful.