### PR TITLE
Improve precision of Lanczos OpenCV4

### DIFF
--- a/src/lanczos/lanczos.jl
+++ b/src/lanczos/lanczos.jl
@@ -120,12 +120,13 @@ function _lanczos4_opencv(δx)
     s0, c0 = sincos(y0)
     cs = ntuple(8) do i
         y = (δx + 4 - i) * p_4
-        # Numerator is the sin subtraction identity
-        # It is equivalent to the following
-        # f(δx,i) = sin( π/4*( 5*(i-1)-δx-3 ) )
+        # Improve precision of Lanczos OpenCV4 #451, avoid NaN
         if iszero(y)
             y = eps(oneunit(y))/8
         end
+        # Numerator is the sin subtraction identity
+        # It is equivalent to the following
+        # f(δx,i) = sin( π/4*( 5*(i-1)-δx-3 ) )
         (l4_2d_cs[i, 1] * s0 + l4_2d_cs[i, 2] * c0) / y^2
     end
     sum_cs = sum(cs)

--- a/src/lanczos/lanczos.jl
+++ b/src/lanczos/lanczos.jl
@@ -14,7 +14,7 @@ This form of interpolation is merely the discrete convolution of the samples wit
 """
 struct Lanczos{N} <: AbstractLanczos
     a::Int
-    
+
     function Lanczos{N}(a) where N
         N < a && @warn "Using a smaller support than scale for Lanczos window. Proceed with caution."
         new{N}(a)
@@ -103,7 +103,7 @@ struct Lanczos4OpenCV <: AbstractLanczos end
 
 degree(::Lanczos4OpenCV) = 4
 
-value_weights(::Lanczos4OpenCV, δx::S) where S = ifelse(isinteger(δx),ntuple(i->convert(float(S), i == 4 - δx), Val(8)) ,_lanczos4_opencv(δx))
+value_weights(::Lanczos4OpenCV, δx) = _lanczos4_opencv(δx)
 
 # s45 = sqrt(2)/2
 const s45 = 0.70710678118654752440084436210485
@@ -123,6 +123,9 @@ function _lanczos4_opencv(δx)
         # Numerator is the sin subtraction identity
         # It is equivalent to the following
         # f(δx,i) = sin( π/4*( 5*(i-1)-δx-3 ) )
+        if iszero(y)
+            y = eps(oneunit(y))
+        end
         (l4_2d_cs[i, 1] * s0 + l4_2d_cs[i, 2] * c0) / y^2
     end
     sum_cs = sum(cs)

--- a/src/lanczos/lanczos.jl
+++ b/src/lanczos/lanczos.jl
@@ -124,7 +124,7 @@ function _lanczos4_opencv(δx)
         # It is equivalent to the following
         # f(δx,i) = sin( π/4*( 5*(i-1)-δx-3 ) )
         if iszero(y)
-            y = eps(oneunit(y))
+            y = eps(oneunit(y))/8
         end
         (l4_2d_cs[i, 1] * s0 + l4_2d_cs[i, 2] * c0) / y^2
     end

--- a/test/lanczos/runtests.jl
+++ b/test/lanczos/runtests.jl
@@ -53,6 +53,7 @@ end
 
     @test 1 < itp(1.5) < 2
     @test 99 < itp(99.5) < 100
+    @test itp(nextfloat(1.0)) ≈ itp(1.0)
 
 
     # symmetry check

--- a/test/lanczos/runtests.jl
+++ b/test/lanczos/runtests.jl
@@ -53,6 +53,7 @@ end
 
     @test 1 < itp(1.5) < 2
     @test 99 < itp(99.5) < 100
+    # Test precision of Lanczos OpenCV4 #451, test not NaN
     @test itp(nextfloat(1.0)) ≈ itp(1.0)
 
 


### PR DESCRIPTION
Formerly Lanczos OpenCV4 could return `NaN` when rounding
yielded truncation. This was hidden by a special rule for integer
shifts, but is revealed by choosing any shift that is within 4eps of
an integer.