### PR TITLE
Splat arguments in gradient `rrule` 

### DIFF
--- a/src/chainrules/chainrules.jl
+++ b/src/chainrules/chainrules.jl
@@ -1,12 +1,16 @@
 export rrule
 """
     ChainRulesCore.rrule(itp::AbstractInterpolation, x...)
+
 ChainRulesCore.jl `rrule` for integration with automatic differentiation libraries.
+Note that it gives the gradient only with respect to the evaluation point `x`,
+and not the data inside `itp`.
 """
 function ChainRulesCore.rrule(itp::AbstractInterpolation, x...)
     y = itp(x...)
-    function pullback(Δy)
-        (ChainRulesCore.NoTangent(), Δy * Interpolations.gradient(itp, x...))
+    function interpolate_pullback(Δy)
+        nope = ChainRulesCore.@not_implemented "`Interpolations.gradient` does not calculate a gradient with respect to the original data, only the evaluation point"
+        (nope, (Δy * Interpolations.gradient(itp, x...))...)
     end
-    y, pullback
+    y, interpolate_pullback
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -9,9 +9,9 @@ using Zygote
     itp = interpolate(y,BSpline(Linear()))
 
     if VERSION ≥ v"1.3"
-        @test Zygote.gradient(itp, 1)[1] == Interpolations.gradient(itp, 1)
+        @test Zygote.gradient(itp, 1) == Tuple(Interpolations.gradient(itp, 1))
     else
-        @test_skip Zygote.gradient(itp, 1)[1] == Interpolations.gradient(itp, 1)
+        @test_skip Zygote.gradient(itp, 1) == Tuple(Interpolations.gradient(itp, 1))
     end
 
     # 2D example
@@ -21,8 +21,8 @@ using Zygote
     itp2 = interpolate(y2, BSpline(Cubic(Line(OnGrid()))))
 
     if VERSION ≥ v"1.3"
-        @test Zygote.gradient(itp2,1,2)[1] == Interpolations.gradient(itp2,1,2)
+        @test Zygote.gradient(itp2,1,2) == Tuple(Interpolations.gradient(itp2,1,2))
     else
-        @test_skip Zygote.gradient(itp2,1,2)[1] == Interpolations.gradient(itp2,1,2)
+        @test_skip Zygote.gradient(itp2,1,2) == Tuple(Interpolations.gradient(itp2,1,2))
     end
 end


### PR DESCRIPTION
I think the return type of the `rrule` defined here is incorrect. There ought to be one number per input, not a vector:
```julia
julia> itp(x,y)
0.7176519f0

julia> Interpolations.gradient(itp, x, y)
2-element StaticArrays.SVector{2, Float32} with indices SOneTo(2):
 -0.70559686
 -1.2178432
 
julia> Zygote.pullback(itp, x, y)[2](1f0)  # should be a tuple of 2 scalars
(Float32[-0.70559686, -1.2178432],)

julia> Zygote.gradient(itp, x, y)
ERROR: MethodError: no method matching (::ChainRulesCore.ProjectTo{Float32, NamedTuple{(), Tuple{}}})(::StaticArrays.SVector{2, Float32})
```
Does `Interpolations.gradient` always return an `SVector`? If so, the splat here should be free. If not, and we might get a `Vector`, then it should probably be replaced.

Unrelated, but `Interpolations.gradient` doesn't compute the gradient with respect to the image etc, only the evaluation point. I think the right way to encode this is a `NotImplemented` object, which should give an error if you try to use it. Returning `NoTangent()` instead means that you will silently get zero. But I am not 100% confident this won't cause surprises. Cc @oxinabox who knows more?

Needs tests. Existing tests here https://github.com/JuliaMath/Interpolations.jl/blob/master/test/chainrules.jl just check that it matches `Interpolations.gradient` (and will fail). One possibility is to use ChainRulesTestUtils for this, which will do elaborate finite-diff tests. But I see there are also more extensive tests here https://github.com/JuliaMath/Interpolations.jl/blob/master/test/gradient.jl so perhaps that's not needed?