### PR TITLE
Safer knot deduplication

### DIFF
--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -86,9 +86,11 @@ check_gridded(::Any, ::Tuple{}, ::Tuple{}) = nothing
 degree(flag::Gridded) = flag.degree
 
 """
-    Interpolations.deduplicate_knots!(knots)
+    Interpolations.deduplicate_knots!(knots; move_knots = false)
 
     Makes knots unique by incrementing repeated but otherwise sorted knots using `nextfloat`.
+    If keyword `move_knots` is true, then `nextfloat` will be applied successively until knots
+    are unique. Otherwise, a warning will be issued.
 
     # Example
 
@@ -106,6 +108,14 @@ degree(flag::Gridded) = flag.degree
     0.0
     20.0
     20.000000000000004
+
+    julia> Interpolations.deduplicate_knots!([1.0, 1.0, 1.0, nextfloat(1.0), nextfloat(1.0)]; move_knots = true)
+    5-element Vector{Float64}:
+    1.0
+    1.0000000000000002
+    1.0000000000000004
+    1.0000000000000007
+    1.0000000000000009
     ```
 """
 function deduplicate_knots!(knots; move_knots::Bool = false)

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -114,7 +114,7 @@ function deduplicate_knots!(knots)
         if i == 1
             continue
         end
-        if knots[i] == last_knot
+        if knots[i] == last_knot || knots[i] <= knots[i-1]
             @inbounds knots[i] = nextfloat(knots[i-1])
         else
             last_knot = @inbounds knots[i]

--- a/src/gridded/gridded.jl
+++ b/src/gridded/gridded.jl
@@ -108,14 +108,18 @@ degree(flag::Gridded) = flag.degree
     20.000000000000004
     ```
 """
-function deduplicate_knots!(knots)
+function deduplicate_knots!(knots; move_knots::Bool = false)
     last_knot = first(knots)
     for i = eachindex(knots)
         if i == 1
             continue
         end
-        if knots[i] == last_knot || knots[i] <= knots[i-1]
+        if knots[i] == last_knot || (move_knots && (@inbounds knots[i] <= knots[i-1]))
             @inbounds knots[i] = nextfloat(knots[i-1])
+        elseif @inbounds knots[i] <= knots[i-1] 
+            @warn "Successive repeated knots detected. Consider using `move_knots` keyword to Interpolations.deduplicate_knots!" last_knot knots[i-1] knots[i]
+            @inbounds knots[i] = nextfloat(knots[i-1])
+            move_knots = true
         else
             last_knot = @inbounds knots[i]
         end

--- a/test/gridded/gridded.jl
+++ b/test/gridded/gridded.jl
@@ -96,8 +96,9 @@ using Interpolations, Test
     knots_not_unique_warning = "Duplicated knots were deduplicated. Use Interpolations.deduplicate_knots!(knots) explicitly to avoid this warning."
     @test_logs (:warn, knots_not_unique_warning) interpolate(knots, [1.0, 1.1, 2.0], Gridded(Linear()))
 
-    # knot deduplication
+    # knot deduplication, issue #467, PR #468
     duplicated_knots = [1.0, 1.0, 1.0, nextfloat(1.0), nextfloat(1.0)]
-    Interpolations.deduplicate_knots!(duplicated_knots)
+    successive_knots_warning = "Successive repeated knots detected. Consider using `move_knots` keyword to Interpolations.deduplicate_knots!"
+    @test_logs (:warn, successive_knots_warning) Interpolations.deduplicate_knots!(duplicated_knots)
     @test allunique(duplicated_knots)
 end

--- a/test/gridded/gridded.jl
+++ b/test/gridded/gridded.jl
@@ -95,4 +95,9 @@ using Interpolations, Test
     # https://github.com/JuliaMath/Interpolations.jl/commit/318ebc88ca1fc084754f3c741266537f901a3310
     knots_not_unique_warning = "Duplicated knots were deduplicated. Use Interpolations.deduplicate_knots!(knots) explicitly to avoid this warning."
     @test_logs (:warn, knots_not_unique_warning) interpolate(knots, [1.0, 1.1, 2.0], Gridded(Linear()))
+
+    # knot deduplication
+    duplicated_knots = [1.0, 1.0, 1.0, nextfloat(1.0), nextfloat(1.0)]
+    Interpolations.deduplicate_knots!(duplicated_knots)
+    @test allunique(duplicated_knots)
 end


### PR DESCRIPTION
This small PR ensures that more pathological cases of duplicated knots (for example `[1.0, 1.0, 1.0, nextfloat(1.0), nextfloat(1.0)]`) are correctly handled.