### PR TITLE
Fix inference regression on 1.7

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -147,18 +147,13 @@ julia> bounds(itp)
 bounds(itp::AbstractInterpolation) = map(twotuple, lbounds(itp), ubounds(itp))
 bounds(itp::AbstractInterpolation, d) = bounds(itp)[d]
 
-itptype(::Type{AbstractInterpolation{T,N,IT}}) where {T,N,IT<:DimSpec{InterpolationType}} = IT
-itptype(::Type{ITP}) where {ITP<:AbstractInterpolation} = itptype(supertype(ITP))
+itptype(::Type{<:AbstractInterpolation{T,N,IT}}) where {T,N,IT<:DimSpec{InterpolationType}} = IT
 itptype(itp::AbstractInterpolation) = itptype(typeof(itp))
-gridtype(::Type{AbstractInterpolation{T,N,IT}}) where {T,N,IT<:DimSpec{InterpolationType}} = GT
-gridtype(::Type{ITP}) where {ITP<:AbstractInterpolation} = gridtype(supertype(ITP))
-gridtype(itp::AbstractInterpolation) = gridtype(typeof(itp))
-ndims(::Type{AbstractInterpolation{T,N,IT}}) where {T,N,IT<:DimSpec{InterpolationType}} = N
-ndims(::Type{ITP}) where {ITP<:AbstractInterpolation} = ndims(supertype(ITP))
-ndims(itp::AbstractInterpolation) = ndims(typeof(itp))
-eltype(::Type{AbstractInterpolation{T,N,IT}}) where {T,N,IT<:DimSpec{InterpolationType}} = T
-eltype(::Type{ITP}) where {ITP<:AbstractInterpolation} = eltype(supertype(ITP))
-eltype(itp::AbstractInterpolation) = eltype(typeof(itp))
+# The following have been defined by AbstractArray
+# ndims(::Type{<:AbstractInterpolation{T,N,<:DimSpec{InterpolationType}}}) where {T,N} = N
+# ndims(itp::AbstractInterpolation) = ndims(typeof(itp))
+# eltype(::Type{<:AbstractInterpolation{T,N,<:DimSpec{InterpolationType}}}) where {T,N} = T
+# eltype(itp::AbstractInterpolation) = eltype(typeof(itp))
 
 """
     n = count_interp_dims(ITP)

--- a/test/core.jl
+++ b/test/core.jl
@@ -71,3 +71,10 @@ end
     @test hash(etp.itp) != 0
     @test hash(etp) != 0
 end
+
+@testset "BasicInferability" begin
+    itp = CubicSplineInterpolation(1:3, randn(3))
+    @test (@inferred Interpolations.itptype(itp)) == BSpline{Cubic{Line{OnGrid}}}
+    @test (@inferred eltype(itp)) == Float64
+    @test (@inferred ndims(itp)) == 1
+end


### PR DESCRIPTION
Since `AbstractInterpolation` <: `AbstractArray`, there's no need to define `ndims` and `eltype` ourself.
`gridtype` is broken, (and unused), so I remove it.
`itptype` is modified to avoid the recursive call of `supertype`.