### PR TITLE
Fix inference on `symmatrix` (patch for #472)

### DIFF
--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -202,7 +202,7 @@ symmatrix(h::NTuple{3,Any}) = SMatrix{2,2}((h[1], h[2], h[2], h[3]))
 symmatrix(h::NTuple{6,Any}) = SMatrix{3,3}((h[1], h[2], h[3], h[2], h[4], h[5], h[3], h[5], h[6]))
 function symmatrix(h::NTuple{L,Any}) where L
     N = symsize(Val(L))
-    l = Matrix{Int}(undef, N, N)
+    l = MMatrix{N,N,Int}(undef)
     l[:,1] = 1:N
     idx = N
     for j = 2:N, i = 1:N

--- a/src/b-splines/indexing.jl
+++ b/src/b-splines/indexing.jl
@@ -220,16 +220,9 @@ function symmatrix(h::NTuple{L,Any}) where L
     end
 end
 
-# Hardcode the output size.
-for N in 4:7
-    L = N*(N+1)÷2
-    @eval symsize(::Val{$L}) = $N
-end
-# When hit the following, L must >= 36 if it's valid.
-# This means we touch the inference limitation (32) of Tuple.
-function symsize(::Val{L}) where L
+# Use @generated to force const propagation
+@generated function symsize(::Val{L}) where L
     N = floor(Int, sqrt(2L))
-    (N*(N+1))÷2 == L || incommensurate(N,L)
-    N
+    (N*(N+1))÷2 == L || error("$L must be equal to N*(N+1)/2 (N = $N)")
+    return :($N)
 end
-@noinline incommensurate(N,L) = error("$L must be equal to N*(N+1)/2 (N = $N)")

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -155,10 +155,14 @@ using Interpolations, Test, ForwardDiff
         @test ForwardDiff.gradient(itp_test, [3.0, 2.0]) ≈ Interpolations.gradient(itp, 3.0, 2.0)
     end
     @testset "issue 469" begin
-        dims = VERSION > v"1.7" ? 7 : 3 # symmatrix is unstable before 1.7, (^ was llvm based)
-        A = zeros(Float64, ntuple(_ -> 5, dims))
-        itp = interpolate(A, BSpline(Quadratic(Reflect(OnCell()))))
-        @test (@inferred Interpolations.hessian(itp, ntuple(_ -> 1.0, dims)...)) == zeros(dims,dims)
+        for dims in 3:7
+            A = zeros(Float64, ntuple(_ -> 5, dims))
+            itp = interpolate(A, BSpline(Quadratic(Reflect(OnCell()))))
+            @test (@inferred Interpolations.hessian(itp, ntuple(_ -> 1.0, dims)...)) == zeros(dims,dims)
+        end
+        @test Interpolations.symsize(Val(36)) == 8
+        @test Interpolations.symsize(Val(45)) == 9
+        @test_throws ErrorException Interpolations.symsize(Val(2))
+        @test_throws ErrorException Interpolations.symsize(Val(33))
     end
-
 end

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -155,7 +155,9 @@ using Interpolations, Test, ForwardDiff
         @test ForwardDiff.gradient(itp_test, [3.0, 2.0]) ≈ Interpolations.gradient(itp, 3.0, 2.0)
     end
     @testset "issue 469" begin
-        for dims in 3:7
+        # We have different inference result on different version.
+        max_dim = VERSION < v"1.3" ? 3 : isdefined(Base, :Any32) ? 7 : 5
+        for dims in 3:max_dim
             A = zeros(Float64, ntuple(_ -> 5, dims))
             itp = interpolate(A, BSpline(Quadratic(Reflect(OnCell()))))
             @test (@inferred Interpolations.hessian(itp, ntuple(_ -> 1.0, dims)...)) == zeros(dims,dims)


### PR DESCRIPTION
This PR hardcoded the output size of `symmatrix` for L < 32 to avoid `sqrt`/`power`, thus also work on 1.6 and 1.7.
For `L > 32`, we'll touch the inference threshold of `Tuple` anyway. Thus more methods seems meaningless.
(I'm not sure why #472 passed previously on 1.7.0. Quite strange.)