### PR TITLE
Add Previous and Next for Constant interpolation 

### DIFF
--- a/docs/src/control.md
+++ b/docs/src/control.md
@@ -119,7 +119,7 @@ NoInterp()
 whereby the coordinate of the selected input vector MUST be located on a grid point. Requests for off grid
 coordinates results in the throwing of an error.
 
-For [`Constant`](@ref) there are the additional parameters. Use `Constant{Previous}()` in order to perform a previous
+For [`Constant`](@ref) there are additional parameters. Use `Constant{Previous}()` in order to perform a previous
 neighbor interpolation. Use `Constant{Next}()` for a next neighbor interpolation.
 Note that rounding can be an issue, see [#473](https://github.com/JuliaMath/Interpolations.jl/issues/473).
 

--- a/docs/src/control.md
+++ b/docs/src/control.md
@@ -119,9 +119,9 @@ NoInterp()
 whereby the coordinate of the selected input vector MUST be located on a grid point. Requests for off grid
 coordinates results in the throwing of an error.
 
-For `Constant()` there are the additional options `Constant{Previous}()` in order to perform a previous
+For [`Constant`](@ref) there are the additional options `Constant{Previous}()` in order to perform a previous
 neighbor interpolation and `Constant{Next}()` for a next neighbor interpolation.
-Note that rounding can be an issue, see [#473](https://github.com/JuliaMath/Interpolations.jl/issues/473)
+Note that rounding can be an issue, see [#473](https://github.com/JuliaMath/Interpolations.jl/issues/473).
 
 `missing` data will naturally propagate through the interpolation,
 where some values will become missing. To avoid that, one can

--- a/docs/src/control.md
+++ b/docs/src/control.md
@@ -119,6 +119,10 @@ NoInterp()
 whereby the coordinate of the selected input vector MUST be located on a grid point. Requests for off grid
 coordinates results in the throwing of an error.
 
+For `Constant()` there are the additional options `Constant{Previous}()` in order to perform a previous
+neighbor interpolation and `Constant{Next}()` for a next neighbor interpolation.
+Note that rounding can be an issue, see [#473](https://github.com/JuliaMath/Interpolations.jl/issues/473)
+
 `missing` data will naturally propagate through the interpolation,
 where some values will become missing. To avoid that, one can
 filter out the missing data points and use a gridded interpolation.

--- a/docs/src/control.md
+++ b/docs/src/control.md
@@ -14,6 +14,14 @@ Some examples:
 itp = interpolate(a, BSpline(Constant()))
 v = itp(5.4)   # returns a[5]
 
+# Previous-neighbor interpolation
+itp = interpolate(a, BSpline(Constant(Previous)))
+v = itp(1.8)   # returns a[1]
+
+# Next-neighbor interpolation
+itp = interpolate(a, BSpline(Constant(Next)))
+v = itp(5.4)   # returns a[6]
+
 # (Multi)linear interpolation
 itp = interpolate(A, BSpline(Linear()))
 v = itp(3.2, 4.1)  # returns 0.9*(0.8*A[3,4]+0.2*A[4,4]) + 0.1*(0.8*A[3,5]+0.2*A[4,5])

--- a/docs/src/control.md
+++ b/docs/src/control.md
@@ -119,8 +119,8 @@ NoInterp()
 whereby the coordinate of the selected input vector MUST be located on a grid point. Requests for off grid
 coordinates results in the throwing of an error.
 
-For [`Constant`](@ref) there are the additional options `Constant{Previous}()` in order to perform a previous
-neighbor interpolation and `Constant{Next}()` for a next neighbor interpolation.
+For [`Constant`](@ref) there are the additional parameters. Use `Constant{Previous}()` in order to perform a previous
+neighbor interpolation. Use `Constant{Next}()` for a next neighbor interpolation.
 Note that rounding can be an issue, see [#473](https://github.com/JuliaMath/Interpolations.jl/issues/473).
 
 `missing` data will naturally propagate through the interpolation,

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -55,6 +55,11 @@ end
 """
 Constant b-splines are *nearest-neighbor* interpolations, and effectively
 return `A[round(Int,x)]` when interpolating.
+
+`Constant{Previous}()` interpolates to the previous value thus equivalent
+to `A[floor(Int,x)]`.
+`Constant{Next}()` interpolates to the next value thus equivalent
+to `A[ceil(Int,x)]`.
 """
 Constant
 

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -55,6 +55,7 @@ end
 """
 Constant b-splines are *nearest-neighbor* interpolations, and effectively
 return `A[round(Int,x)]` when interpolating without scaling.
+Scaling can lead to inaccurate position of the *neighbors* due to limited numerical precision.
 
 `Constant{Previous}` interpolates to the previous value and is thus equivalent
 to `A[floor(Int,x)]` without scaling.

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -54,12 +54,12 @@ end
 
 """
 Constant b-splines are *nearest-neighbor* interpolations, and effectively
-return `A[round(Int,x)]` when interpolating.
+return `A[round(Int,x)]` when interpolating without scaling.
 
-`Constant{Previous}` interpolates to the previous value thus equivalent
-to `A[floor(Int,x)]`.
-`Constant{Next}` interpolates to the next value thus equivalent
-to `A[ceil(Int,x)]`.
+`Constant{Previous}` interpolates to the previous value and is thus equivalent
+to `A[floor(Int,x)]` without scaling.
+`Constant{Next}` interpolates to the next value and is thus equivalent
+to `A[ceil(Int,x)]` without scaling.
 """
 Constant
 

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -3,7 +3,7 @@ export Nearest, Previous, Next
 abstract type ConstantInterpType end
 
 """
-Default option for `Constant` that performes *nearest-neighbor* interpolations.
+Default parameter for `Constant` that performs *nearest-neighbor* interpolation.
 Can optionally be specified as
 ```
 Constant() === Constant{Nearest}()

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -12,7 +12,7 @@ Constant() === Constant{Nearest}()
 struct Nearest <: ConstantInterpType end
 
 """
-Option for `Constant` that performes *previous-neighbor* interpolations.
+Parameter for `Constant` that performs *previous-neighbor* interpolations.
 Applied through 
 ´´´
 Constant{Previous}()

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -21,7 +21,7 @@ Constant{Previous}()
 struct Previous <: ConstantInterpType end
 
 """
-Option for `Constant` that performes *next-neighbor* interpolations.
+Parameter for `Constant` that performs *next-neighbor* interpolations.
 Applied through 
 ```
 Constant{Next}()

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -56,9 +56,9 @@ end
 Constant b-splines are *nearest-neighbor* interpolations, and effectively
 return `A[round(Int,x)]` when interpolating.
 
-`Constant{Previous}()` interpolates to the previous value thus equivalent
+`Constant{Previous}` interpolates to the previous value thus equivalent
 to `A[floor(Int,x)]`.
-`Constant{Next}()` interpolates to the next value thus equivalent
+`Constant{Next}` interpolates to the next value thus equivalent
 to `A[ceil(Int,x)]`.
 """
 Constant

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -1,8 +1,32 @@
 export Nearest, Previous, Next
 
 abstract type ConstantInterpType end
+
+"""
+Default option for `Constant` that performes *nearest-neighbor* interpolations.
+Can optionally be specified as
+```
+Constant() === Constant{Nearest}()
+```
+"""
 struct Nearest <: ConstantInterpType end
+
+"""
+Option for `Constant` that performes *previous-neighbor* interpolations.
+Applied through 
+´´´
+Constant{Previous}()
+´´´
+"""
 struct Previous <: ConstantInterpType end
+
+"""
+Option for `Constant` that performes *next-neighbor* interpolations.
+Applied through 
+```
+Constant{Next}()
+```
+"""
 struct Next <: ConstantInterpType end
 
 struct Constant{T<:ConstantInterpType,BC<:Union{Throw{OnGrid},Periodic{OnCell}}} <: DegreeBC{0}


### PR DESCRIPTION
Fix #511 

I thought of adding `Constant{Mode}()` to the docstring of `interpolate` but was not shure if this is apropriate. Thereby I noted that these docstring have different entries which seem inconsistent/incomplete. E.g. once there is `BSpline(NoInterp())` and once only `NoInterp()`. Also these do not reflect the posibility of using `Gridded`.