### PR TITLE
Try to fix warning

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -27,7 +27,7 @@ function interpolate!(::Type{TWeights}, A, it::IT, gt::GT) where {TWeights,IT<:D
     Base.depwarn("interpolate!($TWeights, A, $it, $gt) is deprecated, use interpolate!($TWeights, A, $bcs)", :interpolate)
     interpolate!(TWeights, A, bcs)
 end
-function interpolate!(A, it::IT, gt::GT) where {TWeights,IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}
+function interpolate!(A, it::IT, gt::GT) where {IT<:DimSpec{BSpline},GT<:DimSpec{GridType}}
     bcs = create_bcs(it, gt)
     Base.depwarn("interpolate!(A, $it, $gt) is deprecated, use interpolate!(A, $bcs)", :interpolate)
     interpolate!(A, bcs)


### PR DESCRIPTION
I get the following warning when loading the library, think this PR should fix it.

```Julia
WARNING: method definition for interpolate! at /Users/jpslewis/.julia/packages/Interpolations/L7A07/src/deprecations.jl:30 declares type variable TWeights but does not use it.
```