### PR TITLE
Adding AkimaMonotonicInterpolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Interpolations"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.14.5"
+version = "0.14.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/monotonic/monotonic.jl
+++ b/src/monotonic/monotonic.jl
@@ -306,23 +306,20 @@ function calcTangents(::Type{TCoeffs}, x::AbstractVector{<:Number},
     n = length(x)
     Δ = Vector{TCoeffs}(undef, n-1)
     m = Vector{TCoeffs}(undef, n)
-
     for k in 1:n-1
         Δk = (y[k+1] - y[k]) / (x[k+1] - x[k])
         Δ[k] = Δk
     end
     Γ = [3Δ[1] - 2Δ[2]; 2Δ[1] - Δ[2]; Δ; 2Δ[n-1] - Δ[n-2]; 3Δ[n-1] - 2Δ[n-2]]
-
     for k in 1:n
         δ = abs(Γ[k+3] - Γ[k+2]) + abs(Γ[k+1] - Γ[k])
-        if δ > 0
+        if δ > zero(δ)
             α = abs(Γ[k+1] - Γ[k]) / δ
             m[k] = (1-α) * Γ[k+1] + α * Γ[k+2]
         else
             m[k] = 0.5 * Γ[k+1] + 0.5 * Γ[k+2]
         end
     end
-
     return (m, Δ)
 end
 

--- a/src/monotonic/monotonic.jl
+++ b/src/monotonic/monotonic.jl
@@ -9,8 +9,8 @@
         "Cardinal"              cubic cardinal splines, uses tension parameter which must be between [0,1]
                                 cubin cardinal splines can overshoot for non-monotonic data
                                 (increasing tension decreases overshoot)
-        "Akima"                 monotonic - tagents are dertermined at each given point locally,
-                                results are close to manual drawn curves
+        "Akima"                 monotonic - tangents are determined at each given point locally,
+                                the curve obtained is close to a manually drawn curve, can overshoot for non-monotonic data
         "FritschCarlson"        monotonic - tangents are first initialized, then adjusted if they are not monotonic
                                 can overshoot for non-monotonic data
         "FritschButland"        monotonic - faster algorithm (only requires one pass) but somewhat higher apparent "tension"
@@ -297,7 +297,7 @@ function calcTangents(::Type{TCoeffs}, x::AbstractVector{<:Number},
 end
 
 function calcTangents(::Type{TCoeffs}, x::AbstractVector{<:Number},
-    y :: AbstractVector{TEl}, method::AkimaMonotonicInterpolation) where {TCoeffs, TEl}
+    y::AbstractVector{TEl}, method::AkimaMonotonicInterpolation) where {TCoeffs, TEl}
 
     # based on Akima (1970),
     # "A New Method of Interpolation and Smooth Curve Fitting Based on Local Procedures",

--- a/test/gradient.jl
+++ b/test/gradient.jl
@@ -185,6 +185,7 @@ using ColorVectorSpace: RGB, Gray, N0f8, Colorant
             CardinalMonotonicInterpolation(0.0),
             CardinalMonotonicInterpolation(0.5),
             CardinalMonotonicInterpolation(1.0),
+            AkimaMonotonicInterpolation(),
             FritschCarlsonMonotonicInterpolation(),
             FritschButlandMonotonicInterpolation(),
             SteffenMonotonicInterpolation()]

--- a/test/hessian.jl
+++ b/test/hessian.jl
@@ -56,6 +56,7 @@ using Test, Interpolations, LinearAlgebra, ForwardDiff
             CardinalMonotonicInterpolation(0.0),
             CardinalMonotonicInterpolation(0.5),
             CardinalMonotonicInterpolation(1.0),
+            AkimaMonotonicInterpolation(),
             FritschCarlsonMonotonicInterpolation(),
             FritschButlandMonotonicInterpolation(),
             SteffenMonotonicInterpolation()]

--- a/test/monotonic/runtests.jl
+++ b/test/monotonic/runtests.jl
@@ -17,6 +17,7 @@ using Unitful
         (CardinalMonotonicInterpolation(0.0), true),
         (CardinalMonotonicInterpolation(0.5), true),
         (CardinalMonotonicInterpolation(1.0), false),
+        (AkimaMonotonicInterpolation(), true),
         (FritschCarlsonMonotonicInterpolation(), true),
         (FritschButlandMonotonicInterpolation(), false),
         (SteffenMonotonicInterpolation(), false)]

--- a/test/plots/monotonic/sanity.jl
+++ b/test/plots/monotonic/sanity.jl
@@ -12,6 +12,7 @@ itypes = [LinearMonotonicInterpolation(),
     CardinalMonotonicInterpolation(0.0),
     CardinalMonotonicInterpolation(0.5),
     CardinalMonotonicInterpolation(1.0),
+    AkimaMonotonicInterpolation(),
     FritschCarlsonMonotonicInterpolation(),
     FritschButlandMonotonicInterpolation(),
     SteffenMonotonicInterpolation()


### PR DESCRIPTION
I added the new interpolation type `AkimaMonotonicInterpolation` and tested the implementation by comparing the results with the results of working code for Akima splines.
I also ran the tests for `@testset "Monotonic"` successfully and checked the plots created by _test/plots/monotonic/sanity.jl_