### PR TITLE
Allow for BSpline type construction via chained pipes

### DIFF
--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -109,6 +109,7 @@ struct InPlaceQ{GT<:Union{GridType,Nothing}} <: BoundaryCondition gt::GT end
 const Natural = Line
 
 (::Type{BC})() where BC<:BoundaryCondition = BC(nothing)
+(::Type{BC})(::Type{GT}) where {GT <: GridType, BC<:BoundaryCondition} = BC{GT}(GT())
 function Base.show(io::IO, bc::BoundaryCondition)
     print(io, nameof(typeof(bc)), '(')
     bc.gt === nothing || show(io, bc.gt)

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -109,7 +109,13 @@ struct InPlaceQ{GT<:Union{GridType,Nothing}} <: BoundaryCondition gt::GT end
 const Natural = Line
 
 (::Type{BC})() where BC<:BoundaryCondition = BC(nothing)
-(::Type{BC})(::Type{GT}) where {GT <: GridType, BC<:BoundaryCondition} = BC{GT}(GT())
+# (::Type{BC})(::Type{GT}) where {GT <: GridType, BC<:BoundaryCondition} = BC{GT}(GT())
+for BC in (:Throw, :Flat, :Line, :Free, :Reflect, :InPlace)
+    eval(quote
+        $BC(::Type{GT}) where GT <: GridType = $BC{GT}(GT())
+        $BC{GT}(::Type{GT}) where GT <: GridType = $BC{GT}(GT())
+    end)
+end
 function Base.show(io::IO, bc::BoundaryCondition)
     print(io, nameof(typeof(bc)), '(')
     bc.gt === nothing || show(io, bc.gt)

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -109,8 +109,7 @@ struct InPlaceQ{GT<:Union{GridType,Nothing}} <: BoundaryCondition gt::GT end
 const Natural = Line
 
 (::Type{BC})() where BC<:BoundaryCondition = BC(nothing)
-# (::Type{BC})(::Type{GT}) where {GT <: GridType, BC<:BoundaryCondition} = BC{GT}(GT())
-for BC in (:Throw, :Flat, :Line, :Free, :Reflect, :InPlace)
+for BC in (:Throw, :Flat, :Line, :Free, :Reflect, :InPlace, :InPlaceQ, :Periodic)
     eval(quote
         $BC(::Type{GT}) where GT <: GridType = $BC{GT}(GT())
         $BC{GT}(::Type{GT}) where GT <: GridType = $BC{GT}(GT())

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -9,6 +9,7 @@ export
 
 abstract type Degree{N} <: Flag end
 abstract type DegreeBC{N} <: Degree{N} end  # degree type supporting a BoundaryCondition
+(::Type{D})(::Type{BC}) where {D <: Degree, BC <: BoundaryCondition} = D(BC())
 
 """
     BSpline(degree)

--- a/src/b-splines/b-splines.jl
+++ b/src/b-splines/b-splines.jl
@@ -22,6 +22,7 @@ struct BSpline{D<:Degree} <: InterpolationType
 end
 
 BSpline(::Type{D}) where D <: Degree = BSpline(D())
+BSpline() = Linear |> BSpline
 
 bsplinetype(::Type{BSpline{D}}) where {D<:Degree} = D
 bsplinetype(::BS) where {BS<:BSpline} = bsplinetype(BS)

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -38,11 +38,11 @@ end
 
 # Default to Nearest and Throw{OnGrid}
 Constant() = Constant{Nearest}()
+Constant(bc::BC) where {BC <: BoundaryCondition} = Constant{Nearest}(bc)
+Constant(::Type{T}) where T <: ConstantInterpType = Constant{T}()
 Constant{T}() where {T<:ConstantInterpType} = Constant{T,Throw{OnGrid}}(Throw(OnGrid()))
 Constant{T}(bc::BC) where {T<:ConstantInterpType,BC<:BoundaryCondition} = Constant{T,BC}(bc)
-Constant(p::Periodic) where {T<:ConstantInterpType} = Constant{Nearest}(p)
 Constant{T}(::Periodic{Nothing}) where {T<:ConstantInterpType} = Constant{T,Periodic{OnCell}}(Periodic(OnCell()))
-Constant(::Type{T}) where T <: ConstantInterpType = Constant{T}()
 
 function Base.show(io::IO, deg::Constant)
     print(io, nameof(typeof(deg)), '{', typeof(deg).parameters[1], '}', '(')

--- a/src/b-splines/constant.jl
+++ b/src/b-splines/constant.jl
@@ -37,9 +37,10 @@ struct Constant{T<:ConstantInterpType,BC<:Union{Throw{OnGrid},Periodic{OnCell}}}
 end
 
 # Default to Nearest and Throw{OnGrid}
-Constant(args...) = Constant{Nearest}(args...)
+Constant() = Constant{Nearest}()
 Constant{T}() where {T<:ConstantInterpType} = Constant{T,Throw{OnGrid}}(Throw(OnGrid()))
 Constant{T}(bc::BC) where {T<:ConstantInterpType,BC<:BoundaryCondition} = Constant{T,BC}(bc)
+Constant(p::Periodic) where {T<:ConstantInterpType} = Constant{Nearest}(p)
 Constant{T}(::Periodic{Nothing}) where {T<:ConstantInterpType} = Constant{T,Periodic{OnCell}}(Periodic(OnCell()))
 Constant(::Type{T}) where T <: ConstantInterpType = Constant{T}()
 

--- a/src/b-splines/cubic.jl
+++ b/src/b-splines/cubic.jl
@@ -5,6 +5,8 @@ end
 (deg::Cubic)(gt::GridType) = Cubic(deg.bc(gt))
 # Default constructor to match cubic_spline_interpolation
 Cubic() = Cubic(Line(OnGrid()))
+Cubic{BC}(::Type{BC}) where BC <: BoundaryCondition = Cubic{BC}(BC())
+Cubic{BC}(::Type{BC2}) where {BC <: BoundaryCondition, BC2 <: BoundaryCondition} = throw(ArgumentError("Argument must match type parameter"))
 
 """
     Cubic(bc::BoundaryCondition)

--- a/src/b-splines/quadratic.jl
+++ b/src/b-splines/quadratic.jl
@@ -3,6 +3,8 @@ struct Quadratic{BC<:BoundaryCondition} <: DegreeBC{2}
 end
 # Default constructor
 Quadratic() = Quadratic(Line(OnGrid()))
+Quadratic{BC}(::Type{BC}) where BC <: BoundaryCondition = Quadratic{BC}(BC())
+Quadratic{BC}(::Type{BC2}) where {BC <: BoundaryCondition, BC2 <: BoundaryCondition} = throw(ArgumentError("Argument must match type parameter"))
 (deg::Quadratic)(gt::GridType) = Quadratic(deg.bc(gt))
 
 

--- a/test/pipes.jl
+++ b/test/pipes.jl
@@ -5,12 +5,17 @@ using Interpolations
     for BC in (Throw, Flat, Line, Free, Reflect, InPlace, InPlaceQ, Periodic)
         for GT in (OnGrid, OnCell)
             @test BC(GT) == BC(GT())
+            @test BC{GT}(GT) == BC{GT}(GT())
             @test GT |> BC == BC(GT())
             for D in (Cubic, Quadratic)
                 @test GT |> BC |> D == D(BC(GT()))
                 @test GT |> BC |> D{BC{GT}} == D(BC(GT()))
+                @test D{BC}(BC) == D{BC}(BC())
             end
         end
+        @test Linear(Throw{OnGrid}) == Linear(Throw{OnGrid}())
     end
     @test BSpline() == BSpline(Linear())
+    @test_throws ArgumentError Cubic{Throw}(Flat)
+    @test_throws ArgumentError Quadratic{Throw}(Flat)
 end

--- a/test/pipes.jl
+++ b/test/pipes.jl
@@ -1,0 +1,16 @@
+using Test
+using Interpolations
+
+@testset "Pipes" begin
+    for BC in (Throw, Flat, Line, Free, Reflect, InPlace, InPlaceQ, Periodic)
+        for GT in (OnGrid, OnCell)
+            @test BC(GT) == BC(GT())
+            @test GT |> BC == BC(GT())
+            for D in (Cubic, Quadratic)
+                @test GT |> BC |> D == D(BC(GT()))
+                @test GT |> BC |> D{BC{GT}} == D(BC(GT()))
+            end
+        end
+    end
+    @test BSpline() == BSpline(Linear())
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ const isci = get(ENV, "CI", "") in ("true", "True")
     include("convenience-constructors.jl")
     include("readme-examples.jl")
     include("iterate.jl")
+    include("pipes.jl")
 
     # Chain rules interaction
     include("chainrules.jl")


### PR DESCRIPTION
The objective of this pull request is to simplify the API. This is accomplished by
1) Providing default constructors. For example, `BSpline()`, `Linear()`, `Cubic()`, `Quadratic()`
2) Allow for chaining via pipes.

```julia
julia> BSpline(Cubic(Line(OnGrid())))
BSpline(Cubic(Line(OnGrid())))

julia> OnGrid |> Line |> Cubic |> BSpline
BSpline(Cubic(Line(OnGrid())))

julia> Line |> Cubic |> BSpline
BSpline(Cubic(Line()))

julia> Cubic |> BSpline
BSpline(Cubic(Line(OnGrid())))

julia> BSpline()
BSpline(Linear())
```