### PR TITLE
Some recursion tuning to allow more eager inference.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Interpolations"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/test/issues/runtests.jl
+++ b/test/issues/runtests.jl
@@ -156,7 +156,7 @@ using Interpolations, Test, ForwardDiff
     end
     @testset "issue 469" begin
         # We have different inference result on different version.
-        max_dim = VERSION < v"1.3" ? 3 : isdefined(Base, :Any32) ? 7 : 5
+        max_dim = isdefined(Base, :Any32) ? 7 : 5
         for dims in 3:max_dim
             A = zeros(Float64, ntuple(_ -> 5, dims))
             itp = interpolate(A, BSpline(Quadratic(Reflect(OnCell()))))

--- a/test/nointerp.jl
+++ b/test/nointerp.jl
@@ -14,3 +14,15 @@
     # @test ae[0,1] === NaN
     # @test_throws InexactError ae(1.5,2)
 end
+
+@testset "Stability of mixtrue with NoInterp and Interp" begin
+    A = zeros(Float64, 5, 5, 5, 5, 5, 5, 5)
+    st = BSpline(Quadratic(Reflect(OnCell()))), NoInterp(),
+         BSpline(Linear()), NoInterp(),
+         BSpline(Quadratic()), NoInterp(),
+         BSpline(Quadratic(Reflect(OnCell())))
+    itp = interpolate(A, st)
+    @test (@inferred Interpolations.hessian(itp, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)) == zeros(4,4)
+    @test (@inferred Interpolations.gradient(itp, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)) == zeros(4)
+    @test (@inferred itp(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)) == 0
+end


### PR DESCRIPTION
Before julia 1.11, indirect recursion might cause unwanted type widening and leading to bad inference.
`itp(...)`, `gradient(itp, ...)`, `hessian(itp, ...)` would therefore become unstable if `itp` has some `NoInterp` dim.
This PR fix it, MWE has been added to Test.