### PR TITLE
Allow integers only for getindex on AbstractInterpolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Interpolations"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.15.1"
+version = "0.16.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,6 +1,4 @@
-# deprecate getindex for non-integer numeric indices
-@deprecate getindex(itp::AbstractInterpolation{T,N}, i::Vararg{Number,N}) where {T,N} itp(i...)
-@deprecate getindex(itp::AbstractInterpolation{T,N}, i::Vararg{ExpandedIndexTypes,N}) where {T,N} itp(i...)
+# Removed with 0.16, indexing via non-integers
 
 for T in (:Throw, :Flat, :Line, :Free, :Periodic, :Reflect, :InPlace, :InPlaceQ)
     @eval begin


### PR DESCRIPTION
Drop deprecated getindex with non-integers
