### PR TITLE
fix syntax typo

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -44,14 +44,14 @@ A = log.(xs)
 ```
 Create linear interpolation object without extrapolation
 ```julia
-interp_linear = linear_interpolation(xs, A)
+interp_linear = LinearInterpolation(xs, A)
 interp_linear(3) # exactly log(3)
 interp_linear(3.1) # approximately log(3.1)
 interp_linear(0.9) # outside grid: error
 ```
 Create linear interpolation object with extrapolation
 ```julia
-interp_linear_extrap = linear_interpolation(xs, A,extrapolation_bc=Line()) 
+interp_linear_extrap = LinearInterpolation(xs, A,extrapolation_bc=Line()) 
 interp_linear_extrap(0.9) # outside grid: linear extrapolation
 ```
 


### PR DESCRIPTION
in current version of docs in the example it suggests the syntax for a linear interpolation is `linear_interpolation` when in fact the module exports this as `LinearInterpolation`