### PR TITLE
Mention KernelInterpolation.jl in section about other packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ interp_linear(0.9) # outside grid: error
 ```
 Create linear interpolation object with extrapolation
 ```julia
-interp_linear_extrap = linear_interpolation(xs, A,extrapolation_bc=Line())
+interp_linear_extrap = linear_interpolation(xs, A,extrapolation_bc=Line()) 
 interp_linear_extrap(0.9) # outside grid: linear extrapolation
 ```
 
@@ -67,7 +67,7 @@ Other interpolation packages for Julia include:
 - [Curves.jl](https://github.com/lungben/Curves.jl) supports log-interpolation via immutable `Curve` objects.
 - [DataInterpolations.jl](https://github.com/SciML/DataInterpolations.jl) is a library for performing interpolations of one-dimensional data.
 - [Dierckx.jl](https://github.com/kbarbary/Dierckx.jl) is a wrapper for the dierckx Fortran library, which also underlies `scipy.interpolate`.
-- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation.
+- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation. 
 - [FastChebInterp.jl](https://github.com/stevengj/FastChebInterp.jl) does fast multidimensional Chebyshev interpolation on a hypercube using separable grid of interpolation points.
 - [FEMBasis.jl](https://github.com/JuliaFEM/FEMBasis.jl) contains interpolation routines for standard finite element function spaces.
 - [FineShift.jl](https://github.com/emmt/FineShift.jl) does fast sub-sample shifting of multidimensional arrays.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ interp_linear(0.9) # outside grid: error
 ```
 Create linear interpolation object with extrapolation
 ```julia
-interp_linear_extrap = linear_interpolation(xs, A,extrapolation_bc=Line()) 
+interp_linear_extrap = linear_interpolation(xs, A,extrapolation_bc=Line())
 interp_linear_extrap(0.9) # outside grid: linear extrapolation
 ```
 
@@ -67,7 +67,7 @@ Other interpolation packages for Julia include:
 - [Curves.jl](https://github.com/lungben/Curves.jl) supports log-interpolation via immutable `Curve` objects.
 - [DataInterpolations.jl](https://github.com/SciML/DataInterpolations.jl) is a library for performing interpolations of one-dimensional data.
 - [Dierckx.jl](https://github.com/kbarbary/Dierckx.jl) is a wrapper for the dierckx Fortran library, which also underlies `scipy.interpolate`.
-- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation. 
+- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation.
 - [FastChebInterp.jl](https://github.com/stevengj/FastChebInterp.jl) does fast multidimensional Chebyshev interpolation on a hypercube using separable grid of interpolation points.
 - [FEMBasis.jl](https://github.com/JuliaFEM/FEMBasis.jl) contains interpolation routines for standard finite element function spaces.
 - [FineShift.jl](https://github.com/emmt/FineShift.jl) does fast sub-sample shifting of multidimensional arrays.
@@ -75,6 +75,7 @@ Other interpolation packages for Julia include:
 - [GeoStats.jl](https://github.com/JuliaEarth/GeoStats.jl) provides interpolation and simulation methods over complex 2D and 3D meshes.
 - [GridInterpolations.jl](https://github.com/sisl/GridInterpolations.jl) performs multivariate interpolation on a rectilinear grid.
 - [InterpolationKernels.jl](https://github.com/emmt/InterpolationKernels.jl) provides a library of interpolation kernels.
+- [KernelInterpolation.jl](https://github.com/JoshuaLampert/KernelInterpolation.jl) implements scattered data interpolations in arbitrary dimensions by radial basis functions with support for solving linear partial differential equations.
 - [KissSmoothing.jl](https://github.com/francescoalemanno/KissSmoothing.jl) implements denoising and a Radial Basis Function estimation procedure.
 - [LinearInterpolations.jl](https://github.com/jw3126/LinearInterpolations.jl) allows for interpolation using weighted averages allowing probability distributions, rotations, and other Lie groups to be interpolated.
 - [LinearInterpolators.jl](https://github.com/emmt/LinearInterpolators.jl) provides linear interpolation methods for Julia based on InterpolationKernels.jl, above.

--- a/docs/src/other_packages.md
+++ b/docs/src/other_packages.md
@@ -9,7 +9,7 @@ Other interpolation packages for Julia include:
 - [Curves.jl](https://github.com/lungben/Curves.jl) supports log-interpolation via immutable `Curve` objects.
 - [DataInterpolations.jl](https://github.com/SciML/DataInterpolations.jl) is a library for performing interpolations of one-dimensional data.
 - [Dierckx.jl](https://github.com/kbarbary/Dierckx.jl) is a wrapper for the dierckx Fortran library, which also underlies `scipy.interpolate`.
-- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation. 
+- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation.
 - [FastChebInterp.jl](https://github.com/stevengj/FastChebInterp.jl) does fast multidimensional Chebyshev interpolation on a hypercube using separable grid of interpolation points.
 - [FEMBasis.jl](https://github.com/JuliaFEM/FEMBasis.jl) contains interpolation routines for standard finite element function spaces.
 - [FineShift.jl](https://github.com/emmt/FineShift.jl) does fast sub-sample shifting of multidimensional arrays.
@@ -17,6 +17,7 @@ Other interpolation packages for Julia include:
 - [GeoStats.jl](https://github.com/JuliaEarth/GeoStats.jl) provides interpolation and simulation methods over complex 2D and 3D meshes.
 - [GridInterpolations.jl](https://github.com/sisl/GridInterpolations.jl) performs multivariate interpolation on a rectilinear grid.
 - [InterpolationKernels.jl](https://github.com/emmt/InterpolationKernels.jl) provides a library of interpolation kernels.
+- [KernelInterpolation.jl](https://github.com/JoshuaLampert/KernelInterpolation.jl) implements scattered data interpolations in arbitrary dimensions by radial basis functions with support for solving linear partial differential equations.
 - [KissSmoothing.jl](https://github.com/francescoalemanno/KissSmoothing.jl) implements denoising and a Radial Basis Function estimation procedure.
 - [LinearInterpolations.jl](https://github.com/jw3126/LinearInterpolations.jl) allows for interpolation using weighted averages allowing probability distributions, rotations, and other Lie groups to be interpolated.
 - [LinearInterpolators.jl](https://github.com/emmt/LinearInterpolators.jl) provides linear interpolation methods for Julia based on InterpolationKernels.jl, above.

--- a/docs/src/other_packages.md
+++ b/docs/src/other_packages.md
@@ -9,7 +9,7 @@ Other interpolation packages for Julia include:
 - [Curves.jl](https://github.com/lungben/Curves.jl) supports log-interpolation via immutable `Curve` objects.
 - [DataInterpolations.jl](https://github.com/SciML/DataInterpolations.jl) is a library for performing interpolations of one-dimensional data.
 - [Dierckx.jl](https://github.com/kbarbary/Dierckx.jl) is a wrapper for the dierckx Fortran library, which also underlies `scipy.interpolate`.
-- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation.
+- [DIVAnd.jl](https://github.com/gher-ulg/DIVAnd.jl) for N-dimensional smoothing interpolation. 
 - [FastChebInterp.jl](https://github.com/stevengj/FastChebInterp.jl) does fast multidimensional Chebyshev interpolation on a hypercube using separable grid of interpolation points.
 - [FEMBasis.jl](https://github.com/JuliaFEM/FEMBasis.jl) contains interpolation routines for standard finite element function spaces.
 - [FineShift.jl](https://github.com/emmt/FineShift.jl) does fast sub-sample shifting of multidimensional arrays.


### PR DESCRIPTION
I have a package [KernelInterpolation.jl](https://github.com/JoshuaLampert/KernelInterpolation.jl), which performs RBF scattered data interpolation. I added it to the list of other interpolation packages.