### PR TITLE
Add 3rd and 4th order convergent cubic convolution interpolation methods with continuous first derivates in any number of dimensions, including extrapolation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 docs/build/
 Manifest.toml
 .vscode
-temp_tester.jl

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 docs/build/
 Manifest.toml
 .vscode
+temp_tester.jl

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -466,7 +466,7 @@ include("lanczos/lanczos_opencv.jl")
 include("iterate.jl")
 include("chainrules/chainrules.jl")
 include("hermite/cubic.jl")
-include("convolution.jl")
+include("cubic_convolution/cubic_convolution.jl")
 if VERSION >= v"1.6"
     include("gpu_support.jl")
 end

--- a/src/Interpolations.jl
+++ b/src/Interpolations.jl
@@ -25,6 +25,7 @@ export
 
     constant_interpolation,
     linear_interpolation,
+    convolution_interpolation,
     cubic_spline_interpolation,
 
     knots,
@@ -465,6 +466,7 @@ include("lanczos/lanczos_opencv.jl")
 include("iterate.jl")
 include("chainrules/chainrules.jl")
 include("hermite/cubic.jl")
+include("convolution.jl")
 if VERSION >= v"1.6"
     include("gpu_support.jl")
 end

--- a/src/convenience-constructors.jl
+++ b/src/convenience-constructors.jl
@@ -30,10 +30,6 @@ cubic_spline_interpolation(ranges::NTuple{N,AbstractRange}, vs::AbstractArray{T,
     extrapolate(scale(interpolate(vs, BSpline(Cubic(bc))), ranges...), extrapolation_bc)
 
 # convolution interpolation
-# convolution_interpolation(knots::Union{AbstractVector,NTuple{N,AbstractVector}}, values::AbstractArray{T}; 
-#     extrapolation_bc = Throw()) where {T,N} = extrapolate(scale(ConvolutionInterpolation(knots isa AbstractVector ? (knots,) : knots, values), knots...), extrapolation_bc)
-# convolution_interpolation(ranges::NTuple{N,AbstractVector}, vs::AbstractArray{T}; 
-#     extrapolation_bc = Throw()) where {T,N} = ConvolutionInterpolation(ranges isa AbstractVector ? (ranges,) : ranges, vs) # extrapolate(, extrapolation_bc)
 function convolution_interpolation(knots::Union{AbstractVector,NTuple{N,AbstractVector}}, values::AbstractArray{T}; 
     extrapolation_bc = Throw()) where {T,N}
     if knots isa AbstractVector

--- a/src/convenience-constructors.jl
+++ b/src/convenience-constructors.jl
@@ -30,13 +30,13 @@ cubic_spline_interpolation(ranges::NTuple{N,AbstractRange}, vs::AbstractArray{T,
     extrapolate(scale(interpolate(vs, BSpline(Cubic(bc))), ranges...), extrapolation_bc)
 
 # convolution interpolation
-function convolution_interpolation(knots::Union{AbstractVector,NTuple{N,AbstractVector}}, values::AbstractArray{T}; 
-    extrapolation_bc = Throw()) where {T,N}
+function convolution_interpolation(knots::Union{AbstractVector,NTuple{N,AbstractVector}}, values::AbstractArray{T,N}; 
+    extrapolation_bc = Throw(), order::Int = 4) where {T,N}
     if knots isa AbstractVector
         knots = (knots,)
     end
-    itp = CubicConvolutionalInterpolation(knots, values)
-    return extrapolate(itp, extrapolation_bc)
+    itp = CubicConvolutionalInterpolation(knots, values, order=order)
+    return Interpolations.extrapolate(itp, extrapolation_bc)
 end
 """
     etp = linear_interpolation(knots, A; extrapolation_bc=Throw())

--- a/src/convenience-constructors.jl
+++ b/src/convenience-constructors.jl
@@ -35,7 +35,7 @@ function convolution_interpolation(knots::Union{AbstractVector,NTuple{N,Abstract
     if knots isa AbstractVector
         knots = (knots,)
     end
-    itp = ConvolutionInterpolation(knots, values)
+    itp = CubicConvolutionalInterpolation(knots, values)
     return extrapolate(itp, extrapolation_bc)
 end
 """

--- a/src/convenience-constructors.jl
+++ b/src/convenience-constructors.jl
@@ -29,6 +29,19 @@ cubic_spline_interpolation(ranges::NTuple{N,AbstractRange}, vs::AbstractArray{T,
                          bc = Line(OnGrid()), extrapolation_bc = Throw()) where {N,T} =
     extrapolate(scale(interpolate(vs, BSpline(Cubic(bc))), ranges...), extrapolation_bc)
 
+# convolution interpolation
+# convolution_interpolation(knots::Union{AbstractVector,NTuple{N,AbstractVector}}, values::AbstractArray{T}; 
+#     extrapolation_bc = Throw()) where {T,N} = extrapolate(scale(ConvolutionInterpolation(knots isa AbstractVector ? (knots,) : knots, values), knots...), extrapolation_bc)
+# convolution_interpolation(ranges::NTuple{N,AbstractVector}, vs::AbstractArray{T}; 
+#     extrapolation_bc = Throw()) where {T,N} = ConvolutionInterpolation(ranges isa AbstractVector ? (ranges,) : ranges, vs) # extrapolate(, extrapolation_bc)
+function convolution_interpolation(knots::Union{AbstractVector,NTuple{N,AbstractVector}}, values::AbstractArray{T}; 
+    extrapolation_bc = Throw()) where {T,N}
+    if knots isa AbstractVector
+        knots = (knots,)
+    end
+    itp = ConvolutionInterpolation(knots, values)
+    return extrapolate(itp, extrapolation_bc)
+end
 """
     etp = linear_interpolation(knots, A; extrapolation_bc=Throw())
 
@@ -66,3 +79,9 @@ rather than using this convenience constructor. Performance will improve
 without scaling or extrapolation.
 """
 cubic_spline_interpolation
+"""
+    etp = convolution_interpolation(knots, values; extrapolation_bc=Throw())
+
+A shorthand for `extrapolate(ConvolutionInterpolation(knots, values), extrapolation_bc)`.
+"""
+convolution_interpolation

--- a/src/convolution.jl
+++ b/src/convolution.jl
@@ -1,0 +1,140 @@
+export ConvolutionInterpolation, ConvolutionMethod
+
+struct ConvolutionKernel end
+
+struct ConvolutionMethod <: InterpolationType end
+
+function (::ConvolutionKernel)(s)
+    s_abs = abs(s)
+    if s_abs < 1.0
+        return (3/2)*s_abs^3 - (5/2)*s_abs^2 + 1
+    elseif s_abs < 2.0
+        return -(1/2)*s_abs^3 + (5/2)*s_abs^2 - 4*s_abs + 2
+    else
+        return 0.0
+    end
+end
+
+struct ConvolutionInterpolation{T,N,TCoefs<:AbstractArray,IT<:NTuple{N,ConvolutionMethod},Axs<:Tuple} <: AbstractInterpolation{T,N,IT}
+    coefs::TCoefs
+    knots::Axs
+    it::IT
+    h::NTuple{N,Float64}
+    kernel::ConvolutionKernel
+end
+
+function ConvolutionInterpolation(knots::NTuple{N,AbstractVector}, vs::AbstractArray{T,N}) where {T,N}
+    if N > 2
+        error("ConvolutionInterpolation is currently implemented only for 1D and 2D. Got $N dimensions.")
+    end
+
+    coefs = create_coefs(knots, vs)
+    h = map(k -> k[2] - k[1], knots)
+    it = ntuple(_ -> ConvolutionMethod(), N)
+    if N == 1
+        knots_new = (knots[1][1]-h[1]:h[1]:knots[1][end]+h[1],)
+    else
+        knots_new = (knots[1][1]-h[1]:h[1]:knots[1][end]+h[1], knots[2][1]-h[2]:h[2]:knots[2][end]+h[2])
+    end
+
+    ConvolutionInterpolation{T,N,typeof(coefs),typeof(it),typeof(knots)}(coefs, (knots_new), it, h, ConvolutionKernel())
+end
+
+function create_coefs(knots::Tuple{AbstractVector}, vs::AbstractVector{T}) where T
+    N = length(vs) + 2
+    c = zeros(T, N)
+    c[2:N-1] = vs
+
+    # 1D boundary conditions
+    c[1] = 3*c[2] - 3*c[3] + c[4]
+    c[N] = 3*c[N-1] - 3*c[N-2] + c[N-3]
+
+    return c
+end
+
+function create_coefs(knots::Tuple{AbstractVector,AbstractVector}, values::AbstractMatrix{T}) where T
+    N, M = size(values) .+ 2
+    c = zeros(T, N, M)
+    c[2:N-1, 2:M-1] = values
+
+    # 2D boundary conditions
+    for k = 2:M-1
+        c[1,k] = 3*c[2,k] - 3*c[3,k] + c[4,k]
+        c[N,k] = 3*c[N-1,k] - 3*c[N-2,k] + c[N-3,k]
+    end
+    for j = 2:N-1
+        c[j,1] = 3*c[j,2] - 3*c[j,3] + c[j,4]
+        c[j,M] = 3*c[j,M-1] - 3*c[j,M-2] + c[j,M-3]
+    end
+    c[1,1] = 3*c[2,1] - 3*c[3,1] + c[4,1]
+    c[N,1] = 3*c[N-1,1] - 3*c[N-2,1] + c[N-3,1]
+    c[1,M] = 3*c[1,M-1] - 3*c[1,M-2] + c[1,M-3]
+    c[N,M] = 3*c[N-1,M] - 3*c[N-2,M] + c[N-3,M]
+
+    return c
+end
+
+function (itp::ConvolutionInterpolation{T,1})(x::Number) where T
+    j = searchsortedlast(itp.knots[1], x)
+
+    if j == 1
+        j = j + 1
+    elseif j == length(itp.knots[1])-1
+        j = j - 1
+    elseif j == length(itp.knots[1])
+        j = j - 2
+    end
+
+    s = (x-itp.knots[1][j])/itp.h[1]
+
+    result = itp.coefs[j-1] * (-s^3 + 2*s^2 - s)/2 + itp.coefs[j] * (3*s^3 - 5*s^2 + 2)/2 +
+            itp.coefs[j+1] * (-3*s^3 + 4*s^2 + s)/2 + itp.coefs[j+2] * (s^3 - s^2)/2  
+
+    return result
+end
+
+function (itp::ConvolutionInterpolation{T,2})(x::Number, y::Number) where T
+    j = searchsortedlast(itp.knots[1], x)
+    k = searchsortedlast(itp.knots[2], y)
+    
+    if j < 1 || j == 1
+        j = 2
+    elseif j == length(itp.knots[1])-1
+        j = j - 1
+    elseif j == length(itp.knots[1])
+        j = j - 2
+    end
+
+    if k < 1 || k == 1
+        k = 2
+    elseif k == length(itp.knots[2])-1
+        k = k - 1
+    elseif k == length(itp.knots[2])
+        k = k - 2
+    end
+
+    result = zero(T)
+    for l = -1:2, m = -1:2
+        result += itp.coefs[j+l, k+m] * 
+                  itp.kernel((x - itp.knots[1][j+l]) / itp.h[1]) * 
+                  itp.kernel((y - itp.knots[2][k+m]) / itp.h[2])
+    end
+    
+    return result
+end
+
+Interpolations.getknots(itp::ConvolutionInterpolation) = itp.knots
+Base.axes(itp::ConvolutionInterpolation) = axes(itp.coefs)
+Base.size(itp::ConvolutionInterpolation) = size(itp.coefs)
+Interpolations.lbounds(itp::ConvolutionInterpolation) = first.(itp.knots)
+Interpolations.ubounds(itp::ConvolutionInterpolation) = last.(itp.knots)
+Interpolations.itpflag(::Type{<:ConvolutionInterpolation{T,N,TCoefs,IT}}) where {T,N,TCoefs,IT} = IT()
+Interpolations.coefficients(itp::ConvolutionInterpolation) = itp.coefs
+
+function Base.getindex(itp::ConvolutionInterpolation{T,1}, x::Number) where T
+    itp(x)
+end
+
+function Base.getindex(itp::ConvolutionInterpolation{T,2}, x::Number, y::Number) where T
+    itp(x, y)
+end

--- a/src/convolution.jl
+++ b/src/convolution.jl
@@ -102,7 +102,7 @@ function create_cubic_convolutional_coefs(knots::Tuple{AbstractVector,AbstractVe
             c[L,j,k] = 3*c[L-1,j,k] - 3*c[L-2,j,k] + c[L-3,j,k]
         end
     end
-    # 6 edges (2 fixed coordinates)
+    # 12 edges (2 fixed coordinates)
     for i = 2:L-1
         c[i,1,1] = 3*c[i,2,1] - 3*c[i,3,1] + c[i,4,1]
         c[i,M,1] = 3*c[i,M-1,1] - 3*c[i,M-2,1] + c[i,M-3,1]

--- a/src/convolution.jl
+++ b/src/convolution.jl
@@ -130,11 +130,3 @@ Interpolations.lbounds(itp::ConvolutionInterpolation) = first.(itp.knots)
 Interpolations.ubounds(itp::ConvolutionInterpolation) = last.(itp.knots)
 Interpolations.itpflag(::Type{<:ConvolutionInterpolation{T,N,TCoefs,IT}}) where {T,N,TCoefs,IT} = IT()
 Interpolations.coefficients(itp::ConvolutionInterpolation) = itp.coefs
-
-function Base.getindex(itp::ConvolutionInterpolation{T,1}, x::Number) where T
-    itp(x)
-end
-
-function Base.getindex(itp::ConvolutionInterpolation{T,2}, x::Number, y::Number) where T
-    itp(x, y)
-end

--- a/src/cubic_convolution/cubic_convolution.jl
+++ b/src/cubic_convolution/cubic_convolution.jl
@@ -1,0 +1,89 @@
+export CubicConvolutionalInterpolation, ConvolutionMethod
+
+# for type stability of specialized coefficient generation
+const Knots1D = Tuple{AbstractVector{T}} where T
+const Knots2D = Tuple{AbstractVector{T}, AbstractVector{T}} where T
+const Knots3D = Tuple{AbstractVector{T}, AbstractVector{T}, AbstractVector{T}} where T
+
+struct ConvolutionMethod <: InterpolationType end
+
+# for type stability of specialized interpolation functions
+struct HigherDimension{N} end
+HigherDimension(::Val{N}) where N = HigherDimension{N}()
+struct OrderOfAccuracy{O} end
+OrderOfAccuracy(::Val{O}) where O = OrderOfAccuracy{O}()
+struct CubicConvolutionalKernel{O} end
+CubicConvolutionalKernel(::Val{O}) where O = CubicConvolutionalKernel{O}()
+
+struct CubicConvolutionalInterpolation{T,N,TCoefs<:AbstractArray,IT<:NTuple{N,ConvolutionMethod},Axs<:Tuple,KA,DT,O} <: AbstractInterpolation{T,N,IT}
+    coefs::TCoefs
+    knots::Axs
+    it::IT
+    h::NTuple{N,Float64}
+    kernel::KA
+    dimension::DT
+    order::O
+end
+
+include("cubic_convolution_coefs.jl")
+include("cubic_convolution_kernels.jl")
+include("cubic_convolution_extrapolation.jl")
+include("cubic_convolution_interpolation.jl")
+
+function CubicConvolutionalInterpolation(knots::NTuple{N,AbstractVector}, vs::AbstractArray{T,N}; order::Int=4) where {T,N}
+    
+    if order == 3
+        coefs = create_cubic_convolutional_coefs(knots, vs) # expand boundaries once
+    elseif order == 4
+        coefs_init = create_cubic_convolutional_coefs(knots, vs)
+        coefs = create_cubic_convolutional_coefs(knots, coefs_init) # expand boundaries twice
+    else
+        throw(ArgumentError("order must be 3 or 4"))
+    end
+
+    h = map(k -> k[2] - k[1], knots)
+    it = ntuple(_ -> ConvolutionMethod(), N)
+
+    if order == 3
+        knots_new = expand_knots(knots, h) # expand boundaries once
+    elseif order == 4
+        knots_init = expand_knots(knots, h)
+        knots_new = expand_knots(knots_init, h) # expand boundaries twice
+    end
+
+    dimension = N <= 3 ? Val(N) : HigherDimension(Val(N))
+    cubickernel = CubicConvolutionalKernel(Val(order))
+    bigO = OrderOfAccuracy(Val(order))
+
+    CubicConvolutionalInterpolation{T,N,typeof(coefs),typeof(it),typeof(knots_new),typeof(cubickernel),typeof(dimension),typeof(bigO)}(
+        coefs, knots_new, it, h, cubickernel, dimension, bigO
+    )
+end
+
+function expand_knots(knots::NTuple{N,AbstractVector}, h::NTuple{N,Real}) where N
+    knots_new = ntuple(i -> knots[i][1]-h[i]:h[i]:knots[i][end]+h[i], N)
+    return knots_new
+end
+
+Interpolations.getknots(itp::CubicConvolutionalInterpolation) = itp.knots
+Base.axes(itp::CubicConvolutionalInterpolation) = axes(itp.coefs)
+Base.size(itp::CubicConvolutionalInterpolation) = size(itp.coefs)
+Interpolations.lbounds(itp::CubicConvolutionalInterpolation) = first.(itp.knots)
+Interpolations.ubounds(itp::CubicConvolutionalInterpolation) = last.(itp.knots)
+Interpolations.itpflag(::Type{<:CubicConvolutionalInterpolation{T,N,TCoefs,IT}}) where {T,N,TCoefs,IT} = IT()
+Interpolations.coefficients(itp::CubicConvolutionalInterpolation) = itp.coefs
+Base.length(itp::CubicConvolutionalInterpolation) = length(itp.coefs)
+Base.iterate(itp::CubicConvolutionalInterpolation, state=1) = state > length(itp) ? nothing : (itp[state], state+1)
+itpflag(itp::CubicConvolutionalInterpolation) = itp.it
+lbound(ax::AbstractRange, itp::ConvolutionMethod) = lbound(ax, itp.order)
+
+# accessing the coefficients
+function Base.getindex(itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,CubicConvolutionalKernel{O},DT,OrderOfAccuracy{O}}, I::Vararg{Integer,N}) where {T,N,TCoefs,IT,Axs,O,DT}
+    return itp.coefs[I...]
+end
+function (itp::CubicConvolutionalInterpolation{T,1,TCoefs,IT,Axs,CubicConvolutionalKernel{O},Val{1},OrderOfAccuracy{O}})(i::Integer) where {T,TCoefs,IT,Axs,O}
+    return itp.coefs[i]
+end
+function (itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,CubicConvolutionalKernel{O},DT,OrderOfAccuracy{O}})(I::Vararg{Integer,N}) where {T,N,TCoefs,IT,Axs,O,DT}
+    return itp.coefs[I...]
+end

--- a/src/cubic_convolution/cubic_convolution_coefs.jl
+++ b/src/cubic_convolution/cubic_convolution_coefs.jl
@@ -1,56 +1,3 @@
-export CubicConvolutionalInterpolation, ConvolutionMethod
-
-# for type stability of specialized coefficient generation
-const Knots1D = Tuple{AbstractVector{T}} where T
-const Knots2D = Tuple{AbstractVector{T}, AbstractVector{T}} where T
-const Knots3D = Tuple{AbstractVector{T}, AbstractVector{T}, AbstractVector{T}} where T
-
-struct CubicConvolutionalKernel end
-
-struct ConvolutionMethod <: InterpolationType end
-
-# for type stability of specialized interpolation functions
-struct HigherDimension{N} end
-HigherDimension(::Val{N}) where N = HigherDimension{N}()
-
-function (::CubicConvolutionalKernel)(s)
-    s_abs = abs(s)
-    if s_abs < 1.0
-        return (3/2)*s_abs^3 - (5/2)*s_abs^2 + 1
-    elseif s_abs < 2.0
-        return -(1/2)*s_abs^3 + (5/2)*s_abs^2 - 4*s_abs + 2
-    else
-        return 0.0
-    end
-end
-
-struct CubicConvolutionalInterpolation{T,N,TCoefs<:AbstractArray,IT<:NTuple{N,ConvolutionMethod},Axs<:Tuple,DT} <: AbstractInterpolation{T,N,IT}
-    coefs::TCoefs
-    knots::Axs
-    it::IT
-    h::NTuple{N,Float64}
-    kernel::CubicConvolutionalKernel
-    dimension::DT
-end
-
-function CubicConvolutionalInterpolation(knots::NTuple{N,AbstractVector}, vs::AbstractArray{T,N}) where {T,N}
-    
-    coefs = create_cubic_convolutional_coefs(knots, vs)
-    h = map(k -> k[2] - k[1], knots)
-    it = ntuple(_ -> ConvolutionMethod(), N)
-
-    knots_new = expand_knots(knots, h)
-
-    dimension = N <= 3 ? Val(N) : HigherDimension(Val(N))
-
-    CubicConvolutionalInterpolation{T,N,typeof(coefs),typeof(it),typeof(knots),typeof(dimension)}(coefs, (knots_new), it, h, CubicConvolutionalKernel(), dimension)
-end
-
-function expand_knots(knots::NTuple{N,AbstractVector}, h::NTuple{N,Real}) where N
-    knots_new = ntuple(i -> knots[i][1]-h[i]:h[i]:knots[i][end]+h[i], N)
-    return knots_new
-end
-
 # specialized dispatch for 1D
 function create_cubic_convolutional_coefs(knots::Knots1D, vs::AbstractVector{T}) where T
     N = length(vs) + 2
@@ -187,6 +134,7 @@ function create_cubic_convolutional_coefs(knots::NTuple{N,AbstractVector}, vs::A
     return c
 end
 
+
 # combinations function
 function combinations(iterable, r)
     pool = collect(iterable)
@@ -215,87 +163,3 @@ function combinations(iterable, r)
     end
     return result
 end
-
-# specialized dispatch for 1D
-function (itp::CubicConvolutionalInterpolation{T,1,TCoefs,IT,Axs,Val{1}})(x::Vararg{T,1}) where {T,TCoefs,IT,Axs}
-    i = searchsortedlast(itp.knots[1], x[1])
-
-    i = limit_convolution_bounds(1, i, itp)
-
-    s = (x[1]-itp.knots[1][i])/itp.h[1]
-
-    result = itp.coefs[i-1] * (-s^3 + 2*s^2 - s)/2 + itp.coefs[i] * (3*s^3 - 5*s^2 + 2)/2 +
-            itp.coefs[i+1] * (-3*s^3 + 4*s^2 + s)/2 + itp.coefs[i+2] * (s^3 - s^2)/2  
-
-    return result
-end
-
-# specialized dispatch for 2D
-function (itp::CubicConvolutionalInterpolation{T,2,TCoefs,IT,Axs,Val{2}})(x::Vararg{T,2}) where {T,TCoefs,IT,Axs}
-    i = searchsortedlast(itp.knots[1], x[1])
-    j = searchsortedlast(itp.knots[2], x[2])
-    
-    i = limit_convolution_bounds(1, i, itp)
-    j = limit_convolution_bounds(2, j, itp)
-
-    result = zero(T)
-    for l = -1:2, m = -1:2
-        result += itp.coefs[i+l, j+m] * 
-                  itp.kernel((x[1] - itp.knots[1][i+l]) / itp.h[1]) * 
-                  itp.kernel((x[2] - itp.knots[2][j+m]) / itp.h[2])
-    end
-    
-    return result
-end
-
-# specialized dispatch for 3D
-function (itp::CubicConvolutionalInterpolation{T,3,TCoefs,IT,Axs,Val{3}})(x::Vararg{T,3}) where {T,TCoefs,IT,Axs}
-    i = searchsortedlast(itp.knots[1], x[1])
-    j = searchsortedlast(itp.knots[2], x[2])
-    k = searchsortedlast(itp.knots[3], x[3])
-
-    i = limit_convolution_bounds(1, i, itp)
-    j = limit_convolution_bounds(2, j, itp)
-    k = limit_convolution_bounds(3, k, itp)
-
-    result = zero(T)
-    for l = -1:2, m = -1:2, n = -1:2
-        result += itp.coefs[i+l, j+m, k+n] * 
-                  itp.kernel((x[1] - itp.knots[1][i+l]) / itp.h[1]) * 
-                  itp.kernel((x[2] - itp.knots[2][j+m]) / itp.h[2]) *
-                  itp.kernel((x[3] - itp.knots[3][k+n]) / itp.h[3])
-    end
-    
-    return result
-end
-
-# generalized dispatch for N > 3
-function (itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,HigherDimension{N}})(x::Vararg{T,N}) where {T,N,TCoefs,IT,Axs}
-
-    pos_ids = ntuple(d -> limit_convolution_bounds(d, ntuple(d -> searchsortedlast(itp.knots[d], x[d]), N)[d], itp), N)
-
-    result = zero(T)
-    for offsets in Iterators.product(ntuple(_ -> -1:2, N)...)
-        result += itp.coefs[(pos_ids .+ offsets)...] * 
-                  prod(itp.kernel((x[d] - itp.knots[d][pos_ids[d] + offsets[d]]) / itp.h[d]) for d in 1:N)
-    end
-    
-    return result
-end
-
-function limit_convolution_bounds(dim::Int, index::Int, itp::CubicConvolutionalInterpolation)
-    if index < 2
-        index = 2
-    elseif index > length(itp.knots[dim]) - 2
-        index = length(itp.knots[dim]) - 2
-    end
-    return index
-end
-
-Interpolations.getknots(itp::CubicConvolutionalInterpolation) = itp.knots
-Base.axes(itp::CubicConvolutionalInterpolation) = axes(itp.coefs)
-Base.size(itp::CubicConvolutionalInterpolation) = size(itp.coefs)
-Interpolations.lbounds(itp::CubicConvolutionalInterpolation) = first.(itp.knots)
-Interpolations.ubounds(itp::CubicConvolutionalInterpolation) = last.(itp.knots)
-Interpolations.itpflag(::Type{<:CubicConvolutionalInterpolation{T,N,TCoefs,IT}}) where {T,N,TCoefs,IT} = IT()
-Interpolations.coefficients(itp::CubicConvolutionalInterpolation) = itp.coefs

--- a/src/cubic_convolution/cubic_convolution_extrapolation.jl
+++ b/src/cubic_convolution/cubic_convolution_extrapolation.jl
@@ -46,6 +46,11 @@ function extrapolate_point(etp::CubicConvolutionalExtrapolation{T,N,ITPT,ET,O}, 
     itp = etp.itp
     knots = getknots(itp)
     
+    function reflect(y, l, u)
+        yr = mod(y - l, 2(u-l)) + l
+        return ifelse(yr > u, 2u-yr, yr)
+    end
+
     clamped_x = zeros(T, N)
     if O == Interpolations.OrderOfAccuracy{3}
         for d in 1:N
@@ -148,11 +153,6 @@ function calculate_component_gradient(etp::CubicConvolutionalExtrapolation{T,N,I
             return (eval_along_dim(2h) - 8 * eval_along_dim(h) + 8 * eval_along_dim(-h) - eval_along_dim(-2h)) / (12h)
         end
     end
-end
-
-function reflect(y, l, u)
-    yr = mod(y - l, 2(u-l)) + l
-    return ifelse(yr > u, 2u-yr, yr)
 end
 
 Interpolations.bounds(etp::CubicConvolutionalExtrapolation) = bounds(etp.itp)

--- a/src/cubic_convolution/cubic_convolution_extrapolation.jl
+++ b/src/cubic_convolution/cubic_convolution_extrapolation.jl
@@ -1,0 +1,158 @@
+struct CubicConvolutionalExtrapolation{T,N,ITPT<:CubicConvolutionalInterpolation,ET<:BoundaryCondition,O} <: AbstractExtrapolation{T,N,ITPT,NTuple{N,ConvolutionMethod}}
+    itp::ITPT
+    et::ET
+end
+
+function Interpolations.extrapolate(itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,KA,DT,O}, et::ET) where {T,N,TCoefs,IT,Axs,KA,DT,O,ET<:BoundaryCondition}
+    CubicConvolutionalExtrapolation{T,N,typeof(itp),ET,O}(itp, et)
+end
+
+Interpolations.getknots(etp::CubicConvolutionalExtrapolation) = getknots(etp.itp)
+Base.size(etp::CubicConvolutionalExtrapolation) = size(etp.itp.coefs)
+Base.axes(etp::CubicConvolutionalExtrapolation) = axes(etp.itp.coefs)
+
+function (etp::CubicConvolutionalExtrapolation{T,N,ITPT,ET,O})(x::Vararg{Number,N}) where {T,N,ITPT,ET,O}
+    itp = etp.itp
+    knots = getknots(itp)
+    
+    # Check if the point is within bounds
+    within_bounds = true
+    if O == Interpolations.OrderOfAccuracy{3}
+        for d in 1:N
+            if x[d] > knots[d][end-1] || x[d] < knots[d][2]
+                within_bounds = false
+                break
+            end
+        end
+    elseif O == Interpolations.OrderOfAccuracy{4}
+        for d in 1:N
+            if x[d] > knots[d][end-2] || x[d] < knots[d][3]
+                within_bounds = false
+                break
+            end
+        end
+    else
+        throw(ArgumentError("Order of accuracy $O not supported"))
+    end
+    
+    if within_bounds
+        return itp(x...)
+    else
+        return extrapolate_point(etp, x)
+    end
+end
+
+function extrapolate_point(etp::CubicConvolutionalExtrapolation{T,N,ITPT,ET,O}, x::NTuple{N,Number}) where {T,N,ITPT,ET,O}
+    itp = etp.itp
+    knots = getknots(itp)
+    
+    clamped_x = zeros(T, N)
+    if O == Interpolations.OrderOfAccuracy{3}
+        for d in 1:N
+            if x[d] < knots[d][2]
+                clamped_x[d] = knots[d][2]
+            elseif x[d] > knots[d][end-1]
+                clamped_x[d] = knots[d][end-1]
+            else
+                clamped_x[d] = x[d]
+            end
+        end
+    elseif O == Interpolations.OrderOfAccuracy{4}
+        for d in 1:N
+            if x[d] < knots[d][3]
+                clamped_x[d] = knots[d][3]
+            elseif x[d] > knots[d][end-2]
+                clamped_x[d] = knots[d][end-2]
+            else
+                clamped_x[d] = x[d]
+            end
+        end
+    else
+        throw(ArgumentError("Order of accuracy $O not supported"))
+    end
+    clamped_x = ntuple(i -> clamped_x[i], N)
+    grad = calculate_gradient(etp, clamped_x)
+    val = itp(clamped_x...)
+
+    for i in 1:N
+        if !isapprox(x[i], clamped_x[i])
+            if etp.et isa Line
+                val += grad[i] * (x[i] - clamped_x[i])
+            elseif etp.et isa Flat
+                # Do nothing, keep the boundary value
+            elseif etp.et isa Periodic
+                if O == Interpolations.OrderOfAccuracy{3}
+                    period = knots[i][end-1] - knots[i][2]
+                    x_periodic = knots[i][2] + mod(x[i] - knots[i][2], period)    
+                elseif O == Interpolations.OrderOfAccuracy{4}
+                    period = knots[i][end-2] - knots[i][3]
+                    x_periodic = knots[i][3] + mod(x[i] - knots[i][3], period)    
+                else
+                    throw(ArgumentError("Order of accuracy $O not supported"))
+                end
+                val = itp(ntuple(j -> j == i ? x_periodic : clamped_x[j], N)...)
+            elseif etp.et isa Reflect
+                if O == Interpolations.OrderOfAccuracy{3}
+                    x_reflect = reflect(x[i], knots[i][2], knots[i][end-1])
+                elseif O == Interpolations.OrderOfAccuracy{4}
+                    x_reflect = reflect(x[i], knots[i][3], last(knots[i][end-2]))
+                else
+                    throw(ArgumentError("Order of accuracy $O not supported"))
+                end
+                val = itp(ntuple(j -> j == i ? x_reflect : clamped_x[j], N)...)
+            elseif etp.et isa Throw
+                throw(BoundsError(itp, x))
+            end
+        end
+    end
+    
+    return val
+end
+
+function calculate_gradient(etp::CubicConvolutionalExtrapolation{T,N,ITPT,ET,O}, x::NTuple{N,Number}) where {T,N,ITPT,ET,O}
+    itp = etp.itp
+    knots = getknots(itp)
+    grad = zeros(T, N)
+
+    for d in 1:N
+        grad[d] = calculate_component_gradient(etp, x, d)
+    end
+
+    return grad
+end
+
+function calculate_component_gradient(etp::CubicConvolutionalExtrapolation{T,N,ITPT,ET,O}, x::NTuple{N,Number}, d::Int) where {T,N,ITPT,ET,O}
+    itp = etp.itp
+    knots = getknots(itp)
+    h = etp.itp.h[d] * 1e-6  # Small step size
+
+    # Helper function to evaluate interpolator along dimension d
+    function eval_along_dim(offset)
+        return itp(ntuple(i -> i == d ? x[i] + offset : x[i], N)...)
+    end
+
+    if O == Interpolations.OrderOfAccuracy{3}
+        if x[d] ≈ knots[d][2]  # Left boundary
+            return (-11 * eval_along_dim(0) + 18 * eval_along_dim(h) - 9 * eval_along_dim(2h) + 2 * eval_along_dim(3h)) / (6h)
+        elseif x[d] ≈ knots[d][end-1]  # Right boundary
+            return (11 * eval_along_dim(0) - 18 * eval_along_dim(-h) + 9 * eval_along_dim(-2h) - 2 * eval_along_dim(-3h)) / (6h)
+        else  # Interior point
+            return (eval_along_dim(2h) - 8 * eval_along_dim(h) + 8 * eval_along_dim(-h) - eval_along_dim(-2h)) / (12h)
+        end
+    elseif O == Interpolations.OrderOfAccuracy{4}
+        if x[d] ≈ knots[d][3]  # Left boundary
+            return (-11 * eval_along_dim(0) + 18 * eval_along_dim(h) - 9 * eval_along_dim(2h) + 2 * eval_along_dim(3h)) / (6h)
+        elseif x[d] ≈ knots[d][end-2]  # Right boundary
+            return (11 * eval_along_dim(0) - 18 * eval_along_dim(-h) + 9 * eval_along_dim(-2h) - 2 * eval_along_dim(-3h)) / (6h)
+        else  # Interior point
+            return (eval_along_dim(2h) - 8 * eval_along_dim(h) + 8 * eval_along_dim(-h) - eval_along_dim(-2h)) / (12h)
+        end
+    end
+end
+
+function reflect(y, l, u)
+    yr = mod(y - l, 2(u-l)) + l
+    return ifelse(yr > u, 2u-yr, yr)
+end
+
+Interpolations.bounds(etp::CubicConvolutionalExtrapolation) = bounds(etp.itp)

--- a/src/cubic_convolution/cubic_convolution_interpolation.jl
+++ b/src/cubic_convolution/cubic_convolution_interpolation.jl
@@ -1,0 +1,97 @@
+# specialized dispatch for 1D
+function (itp::CubicConvolutionalInterpolation{T,1,TCoefs,IT,Axs,KA,Val{1},OrderOfAccuracy{O}})(x::Vararg{T,1}) where {T,TCoefs,IT,Axs,KA,O}
+
+    i = limit_convolution_bounds(1, searchsortedlast(itp.knots[1], x[1]), itp)
+
+    result = zero(T)
+    for l = (O == 3 ? (-1:2) : (-2:3))
+        result += itp.coefs[i+l] * 
+                  itp.kernel((x[1] - itp.knots[1][i+l]) / itp.h[1])
+    end
+    
+    return result
+end
+
+# specialized dispatch for 2D
+function (itp::CubicConvolutionalInterpolation{T,2,TCoefs,IT,Axs,KA,Val{2},OrderOfAccuracy{O}})(x::Vararg{T,2}) where {T,TCoefs,IT,Axs,KA,O}
+
+    i = limit_convolution_bounds(1, searchsortedlast(itp.knots[1], x[1]), itp)
+    j = limit_convolution_bounds(2, searchsortedlast(itp.knots[2], x[2]), itp)
+
+    result = zero(T)
+    for l = (O == 3 ? (-1:2) : (-2:3)), m = (O == 3 ? (-1:2) : (-2:3))
+        result += itp.coefs[i+l, j+m] * 
+                  itp.kernel((x[1] - itp.knots[1][i+l]) / itp.h[1]) * 
+                  itp.kernel((x[2] - itp.knots[2][j+m]) / itp.h[2])
+    end
+    
+    return result
+end
+
+# specialized dispatch for 3D
+function (itp::CubicConvolutionalInterpolation{T,3,TCoefs,IT,Axs,KA,Val{3},OrderOfAccuracy{O}})(x::Vararg{T,3}) where {T,TCoefs,IT,Axs,KA,O}
+
+    i = limit_convolution_bounds(1, searchsortedlast(itp.knots[1], x[1]), itp)
+    j = limit_convolution_bounds(2, searchsortedlast(itp.knots[2], x[2]), itp)
+    k = limit_convolution_bounds(3, searchsortedlast(itp.knots[3], x[3]), itp)
+
+    result = zero(T)
+    for l = (O == 3 ? (-1:2) : (-2:3)), m = (O == 3 ? (-1:2) : (-2:3)), n = (O == 3 ? (-1:2) : (-2:3))
+        result += itp.coefs[i+l, j+m, k+n] * 
+                  itp.kernel((x[1] - itp.knots[1][i+l]) / itp.h[1]) * 
+                  itp.kernel((x[2] - itp.knots[2][j+m]) / itp.h[2]) *
+                  itp.kernel((x[3] - itp.knots[3][k+n]) / itp.h[3])
+    end
+    
+    return result
+end
+
+# generalized dispatch for N > 3
+function (itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,KA,HigherDimension{N},OrderOfAccuracy{O}})(x::Vararg{T,N}) where {T,N,TCoefs,IT,KA,Axs,O}
+
+    pos_ids = ntuple(d -> limit_convolution_bounds(d, ntuple(d -> searchsortedlast(itp.knots[d], x[d]), N)[d], itp), N)
+
+    result = zero(T)
+    for offsets in Iterators.product(ntuple(_ -> (O == 3 ? (-1:2) : (-2:3)), N)...)
+        result += itp.coefs[(pos_ids .+ offsets)...] * 
+                  prod(itp.kernel((x[d] - itp.knots[d][pos_ids[d] + offsets[d]]) / itp.h[d]) for d in 1:N)
+    end
+    
+    return result
+end
+
+function limit_convolution_bounds(dim::Int, index::Int, itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,CubicConvolutionalKernel{3},Val{N},OrderOfAccuracy{3}}) where {T,N,TCoefs,IT,Axs}
+    if index < 2
+        index = 2
+    elseif index > length(itp.knots[dim]) - 2
+        index = length(itp.knots[dim]) - 2
+    end
+    return index
+end
+
+function limit_convolution_bounds(dim::Int, index::Int, itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,CubicConvolutionalKernel{3},HigherDimension{N},OrderOfAccuracy{3}}) where {T,N,TCoefs,IT,Axs}
+    if index < 2
+        index = 2
+    elseif index > length(itp.knots[dim]) - 2
+        index = length(itp.knots[dim]) - 2
+    end
+    return index
+end
+
+function limit_convolution_bounds(dim::Int, index::Int, itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,CubicConvolutionalKernel{4},Val{N},OrderOfAccuracy{4}}) where {T,N,TCoefs,IT,Axs}
+    if index < 3
+        index = 3
+    elseif index > length(itp.knots[dim]) - 3
+        index = length(itp.knots[dim]) - 3
+    end
+    return index
+end
+
+function limit_convolution_bounds(dim::Int, index::Int, itp::CubicConvolutionalInterpolation{T,N,TCoefs,IT,Axs,CubicConvolutionalKernel{4},HigherDimension{N},OrderOfAccuracy{4}}) where {T,N,TCoefs,IT,Axs}
+    if index < 3
+        index = 3
+    elseif index > length(itp.knots[dim]) - 3
+        index = length(itp.knots[dim]) - 3
+    end
+    return index
+end

--- a/src/cubic_convolution/cubic_convolution_kernels.jl
+++ b/src/cubic_convolution/cubic_convolution_kernels.jl
@@ -1,0 +1,24 @@
+function (::CubicConvolutionalKernel{3})(s)
+    s_abs = abs(s)
+    if s_abs < 1.0
+        return (3/2)*s_abs^3 - (5/2)*s_abs^2 + 1
+    elseif s_abs < 2.0
+        return -(1/2)*s_abs^3 + (5/2)*s_abs^2 - 4*s_abs + 2
+    else
+        return 0.0
+    end
+end
+
+function (::CubicConvolutionalKernel{4})(s)
+    s_abs = abs(s)
+    if s_abs < 1.0
+        return (4/3)*s_abs^3 - (7/3)*s_abs^2 + 1
+    elseif s_abs < 2.0
+        return -(7/12)*s_abs^3 + 3*s_abs^2 - (59/12)*s_abs + 15/6
+    elseif s_abs < 3.0
+        return (1/12)*s_abs^3 - (2/3)*s_abs^2 + (21/12)*s_abs - 3/2
+    else
+        return 0.0
+    end
+    
+end

--- a/test/cubic_convolution.jl
+++ b/test/cubic_convolution.jl
@@ -1,0 +1,113 @@
+using Test
+
+function cubic_convolution_test()
+    N = 3
+
+    ### 1D
+    range_1d = range(0.0, stop=1.0, length=N)
+
+    # random uniformly spaced 1D data
+    vals_1d_rand = rand(N)
+    itp_1d_rand = convolution_interpolation(range_1d, vals_1d_rand, extrapolation_bc=Interpolations.Line())
+    @test itp_1d_rand.(range_1d) ≈ vals_1d_rand
+    
+    # match mean of linear uniformly spaced 1D data
+    vals_1d_linear = range(0.0, stop=1.0, length=N)
+    vals_1d_linear_mean =[(vals_1d_linear[i]+vals_1d_linear[i+1])/2 for i in 1:N-1]
+    itp_1d_linear = convolution_interpolation(range_1d, vals_1d_linear, extrapolation_bc=Interpolations.Line())
+    @test itp_1d_linear.(range(vals_1d_linear_mean[1], stop=vals_1d_linear_mean[end], length=N-1)) ≈ vals_1d_linear_mean
+
+    # extrapolation
+    etp_1d_linear = convolution_interpolation(range_1d, vals_1d_linear, extrapolation_bc=Interpolations.Line())
+    @test etp_1d_linear.([-0.2, -0.1, 1.1, 1.2]) ≈ [-0.2, -0.1, 1.1, 1.2]
+    etp_1d_flat = convolution_interpolation(range_1d, vals_1d_linear, extrapolation_bc=Interpolations.Flat())
+    @test etp_1d_flat.([-0.2, -0.1, 1.1, 1.2]) ≈ [0.0, 0.0, 1.0, 1.0]
+
+    ### 2D
+    range_2d = range(0.0, stop=1.0, length=N)
+    
+    # random uniformly spaced 2D data
+    vals_2d_rand = rand(N,N)
+    itp_2d_rand = convolution_interpolation((range_1d, range_2d), vals_2d_rand, extrapolation_bc=Interpolations.Line())
+    @test [itp_2d_rand(range_1d[i], range_2d[j]) for i in 1:N for j in 1:N] ≈ [vals_2d_rand[i,j] for i in 1:N for j in 1:N]
+
+    # mean of linear uniformly spaced 2D data
+    f_2d_linear(i,j) = (i-1)/(N-1)+(j-1)/(N-1)
+    vals_2d_linear = Matrix{Float64}(undef, N, N)
+    [vals_2d_linear[i,j] = f_2d_linear(i,j) for i in 1:N for j in 1:N]
+    vals_2d_linear_mean =[(f_2d_linear(i,j)+f_2d_linear(i+1,j)+f_2d_linear(i,j+1)+f_2d_linear(i+1,j+1))/4 for i in 1:N-1 for j in 1:N-1]
+    itp_2d_linear = convolution_interpolation((range_1d, range_2d,), vals_2d_linear, extrapolation_bc=Interpolations.Line())
+    @test [itp_2d_linear((i-1/2)/(N-1),(j-1/2)/(N-1)) for i in 1:N-1 for j in 1:N-1][:] ≈ vals_2d_linear_mean
+
+    # extrapolation
+    etp_2d_linear = convolution_interpolation((range_1d, range_2d,), vals_2d_linear, extrapolation_bc=Interpolations.Line())
+    @test [etp_2d_linear(i, i) for i in [-0.2, -0.1, 1.1, 1.2]] ≈ [-0.4, -0.2, 2.2, 2.4]
+    etp_2d_flat = convolution_interpolation((range_1d, range_2d,), vals_2d_linear, extrapolation_bc=Interpolations.Flat())
+    @test [etp_2d_flat(i, i) for i in [-0.2, -0.1, 1.1, 1.2]] ≈ [0.0, 0.0, 2.0, 2.0]
+    
+    ### 3D
+    range_3d = range(0.0, stop=1.0, length=N)
+
+    # random uniformly spaced 3D data
+    vals_3d_rand = rand(N,N,N)
+    itp_3d_rand = convolution_interpolation((range_1d, range_2d, range_3d), vals_3d_rand, extrapolation_bc=Interpolations.Line())
+    @test [itp_3d_rand(range_1d[i], range_2d[j], range_3d[k]) for i in 1:N for j in 1:N for k in 1:N] ≈ [vals_3d_rand[i,j,k] for i in 1:N for j in 1:N for k in 1:N]
+
+    # mean of linear uniformly spaced 3D data
+    f_3d_linear(i,j,k) = (i-1)/(N-1)+(j-1)/(N-1)+(k-1)/(N-1)
+    vals_3d_linear = Array{Float64}(undef, N, N, N)
+    [vals_3d_linear[i,j,k] = f_3d_linear(i,j,k) for i in 1:N for j in 1:N for k in 1:N]
+    vals_3d_linear_mean =[(f_3d_linear(i,j,k)+f_3d_linear(i+1,j,k)+f_3d_linear(i,j+1,k)+f_3d_linear(i,j,k+1)+
+                            f_3d_linear(i+1,j+1,k+1)+f_3d_linear(i,j+1,k+1)+f_3d_linear(i+1,j,k+1)+f_3d_linear(i+1,j+1,k))/8 for i in 1:N-1 for j in 1:N-1 for k in 1:N-1]
+    itp_3d_linear = convolution_interpolation((range_1d, range_2d, range_3d), vals_3d_linear, extrapolation_bc=Interpolations.Line())
+    @test [itp_3d_linear((i-1/2)/(N-1),(j-1/2)/(N-1),(k-1/2)/(N-1)) for i in 1:N-1 for j in 1:N-1 for k in 1:N-1][:] ≈ vals_3d_linear_mean
+
+    # extrapolation
+    etp_3d_linear = convolution_interpolation((range_1d, range_2d, range_3d), vals_3d_linear, extrapolation_bc=Interpolations.Line())
+    @test isapprox([etp_3d_linear(i, i, i) for i in [-0.2, -0.1, 1.1, 1.2]], [-0.6, -0.3, 3.3, 3.6], atol=1e-3)
+    etp_3d_flat = convolution_interpolation((range_1d, range_2d, range_3d), vals_3d_linear, extrapolation_bc=Interpolations.Flat())
+    @test [etp_3d_flat(i, i, i) for i in [-0.2, -0.1, 1.1, 1.2]] ≈ [0.0, 0.0, 3.0, 3.0]
+
+    ### 4D
+    range_4d = range(0.0, stop=1.0, length=N)
+
+    # random uniformly spaced 4D data
+    vals_4d_rand = rand(N,N,N,N)
+    itp_4d_rand = convolution_interpolation((range_1d, range_2d, range_3d, range_4d), vals_4d_rand, extrapolation_bc=Interpolations.Line())
+    @test [itp_4d_rand(range_1d[i], range_2d[j], range_3d[k], range_4d[l]) for i in 1:N for j in 1:N for k in 1:N for l in 1:N] ≈ [vals_4d_rand[i,j,k,l] for i in 1:N for j in 1:N for k in 1:N for l in 1:N]
+
+    # mean of linear uniformly spaced 4D data
+    f_4d_linear(i,j,k,l) = (i-1)/(N-1)+(j-1)/(N-1)+(k-1)/(N-1)+(l-1)/(N-1)
+    vals_4d_linear = Array{Float64}(undef, N, N, N, N)
+    [vals_4d_linear[i,j,k,l] = f_4d_linear(i,j,k,l) for i in 1:N for j in 1:N for k in 1:N for l in 1:N]
+    function hypercube_mean(f_4d_linear, N)
+        [(
+            f_4d_linear(i, j, k, l) +
+            f_4d_linear(i+1, j, k, l) +
+            f_4d_linear(i, j+1, k, l) +
+            f_4d_linear(i, j, k+1, l) +
+            f_4d_linear(i, j, k, l+1) +
+            f_4d_linear(i+1, j+1, k, l) +
+            f_4d_linear(i+1, j, k+1, l) +
+            f_4d_linear(i+1, j, k, l+1) +
+            f_4d_linear(i, j+1, k+1, l) +
+            f_4d_linear(i, j+1, k, l+1) +
+            f_4d_linear(i, j, k+1, l+1) +
+            f_4d_linear(i+1, j+1, k+1, l) +
+            f_4d_linear(i+1, j+1, k, l+1) +
+            f_4d_linear(i+1, j, k+1, l+1) +
+            f_4d_linear(i, j+1, k+1, l+1) +
+            f_4d_linear(i+1, j+1, k+1, l+1)
+        ) / 16 for i in 1:N-1, j in 1:N-1, k in 1:N-1, l in 1:N-1]
+    end
+    vals_4d_linear_mean = hypercube_mean(f_4d_linear, N)
+    itp_4d_linear = convolution_interpolation((range_1d, range_2d, range_3d, range_4d), vals_4d_linear, extrapolation_bc=Interpolations.Line())
+    @test [itp_4d_linear((i-1/2)/(N-1),(j-1/2)/(N-1),(k-1/2)/(N-1),(l-1/2)/(N-1)) for i in 1:N-1 for j in 1:N-1 for k in 1:N-1 for l in 1:N-1] ≈ vals_4d_linear_mean[:]
+
+    # test extrapolation bc
+    etp_4d_linear = convolution_interpolation((range_1d, range_2d, range_3d, range_4d), vals_4d_linear, extrapolation_bc=Interpolations.Line())
+    @test [etp_4d_linear( i, i, i, i) for i in [-0.2, -0.1, 1.1, 1.2]] ≈ [-0.8, -0.4, 4.4, 4.8]
+    etp_4d_flat = convolution_interpolation((range_1d, range_2d, range_3d, range_4d), vals_4d_linear, extrapolation_bc=Interpolations.Flat())
+    @test [etp_4d_flat( i, i, i, i) for i in [-0.2, -0.1, 1.1, 1.2]] ≈ [0.0, 0.0, 4.0, 4.0]
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,9 @@ const isci = get(ENV, "CI", "") in ("true", "True")
     # gridded interpolation tests
     include("gridded/runtests.jl")
 
+    # convolution interpolation tests
+    include("cubic_convolution.jl")
+
     # test interpolation with specific types
     include("typing.jl")
 


### PR DESCRIPTION
Hi interpolators!

I noticed there had been a wish for gridded spline interpolations for a while.
I do not know how to accomplish gridded spline interpolations, but I had an implementation of a cubic convolution algorithm which I have translated. It implements "Cubic Convolution Interpolation for Digital Image
Processing" by Robert G. Keys (1981) IEEE Transactions On Acoustics, Speech, And Signal Processing, vol. ASSP-29, no. 6, December 1981.

I have attempted to implement it according to the package standards with a constructor and an interpolator (it also supports extrapolation). It supports interpolation in any number of dimensions, it has continuous first derivatives and feature both a 3rd and 4th order convergent implementation. The fact that this algorithm does not require continuous second derivatives can be an advantage in some cases, if one desires less overshoot than cubic splines achieves. This is especially true for the 3rd order cubic convolution interpolation, and as such it may be viewed as a compromise between splines and linear interpolation.

Kind regards, Nikolaj