### PR TITLE
move test for method ambiguities inside outermost testset

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,12 @@ using Test, SharedArrays, Random, ColorVectorSpace
 using StaticArrays, WoodburyMatrices
 using Interpolations
 
-@test isempty(detect_ambiguities(Interpolations))
 
 const isci = get(ENV, "CI", "") in ("true", "True")
 
 @testset "Interpolations" begin
+    @test isempty(detect_ambiguities(Interpolations))
+
     include("core.jl")
     # Hermite interpolation tests
     include("cubic_hermite.jl")


### PR DESCRIPTION
Recently, CI has been failing quickly for this repo, because there is test for method ambiguities which is outside the outermost `@testset`.  When it fails (which is happening currently), the rest of the tests don't run.

