### PR TITLE
Only import the Zygote from Zygote; fix tests

### DIFF
--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,4 +1,4 @@
-using Zygote
+using Zygote: Zygote
 @testset "ChainRulesCore" begin
     # 1D example
     x = 1:10


### PR DESCRIPTION
Because of multiple imports of gradient and hessian, there were name clashes
